### PR TITLE
[WIP] Add Flag

### DIFF
--- a/ban/auth/models.py
+++ b/ban/auth/models.py
@@ -53,6 +53,8 @@ class Client(ResourceModel):
         (GRANT_CLIENT_CREDENTIALS, _('Client credentials')),
     )
     default_scopes = ['contrib']
+    FLAGS = ['ign', 'laposte', 'local_authority']
+    FLAG_IDS = tuple((i, i) for i in FLAGS) + (None, 'None')
 
     client_id = db.UUIDField(unique=True, default=uuid.uuid4)
     name = db.CharField(max_length=100)
@@ -61,6 +63,7 @@ class Client(ResourceModel):
     redirect_uris = db.ArrayField(db.CharField)
     grant_type = db.CharField(choices=GRANT_TYPES)
     is_confidential = db.BooleanField(default=False)
+    flag_id = db.CharField(choices=FLAG_IDS, default=None, null=True)
 
     @property
     def default_redirect_uri(self):

--- a/ban/commands/db.py
+++ b/ban/commands/db.py
@@ -1,7 +1,7 @@
 from ban.auth import models as amodels
 from ban.commands import command, reporter
 from ban.core import models as cmodels
-from ban.core.versioning import Diff, Version, IdentifierRedirect
+from ban.core.versioning import Diff, Version, IdentifierRedirect, Flag
 
 from . import helpers
 
@@ -9,7 +9,7 @@ models = [Version, Diff, IdentifierRedirect, amodels.User, amodels.Client,
           amodels.Grant, amodels.Session, amodels.Token, cmodels.Municipality,
           cmodels.PostCode, cmodels.Group, cmodels.HouseNumber,
           cmodels.HouseNumber.ancestors.get_through_model(),
-          cmodels.Position]
+          cmodels.Position, Flag]
 
 
 @command

--- a/ban/core/validators.py
+++ b/ban/core/validators.py
@@ -100,11 +100,11 @@ class VersionedResourceValidator(ResourceValidator):
         if self.instance and claimed_version <= current_version > 1:
             base = self.instance.load_version(claimed_version - 1)
             current = self.instance.load_version(current_version)
-            diff = make_diff(base.as_resource, current.as_resource)
+            diff = make_diff(base.data, current.data)
             # Those are keys changed between that last know version of the
             # client and the current version we have.
             protected = diff.keys()
-            diff = make_diff(base.as_resource, self.document,
+            diff = make_diff(base.data, self.document,
                              update=self.update)
             conflict = any(k in protected for k in diff.keys())
             if not conflict:

--- a/ban/core/versioning.py
+++ b/ban/core/versioning.py
@@ -1,14 +1,32 @@
 from datetime import datetime
 import json
 
+import decorator
 import peewee
 
 from ban import db
-from ban.auth.models import Session
+from ban.auth.models import Client, Session
 from ban.core.encoder import dumps
 from ban.utils import make_diff
 
 from . import context
+
+
+@decorator.decorator
+def flag_id_required(func, self, *args, **kwargs):
+    session = context.get('session')
+    if not session:
+        raise ValueError('Must be logged in.')
+    if not session.client:
+        raise ValueError('Token must be linked to a client.')
+    if not session.client.flag_id:
+        raise ValueError('Client must have a valid flag_id.')
+
+    # Even if session is declared as kwarg, "decorator" helper injects it
+    # as arg. Bad.
+    args = list(args)
+    args[0] = session
+    func(self, *args, **kwargs)
 
 
 class ForcedVersionError(Exception):
@@ -53,7 +71,7 @@ class Versioned(db.Model, metaclass=BaseVersioned):
             model_name=self.__class__.__name__,
             model_pk=self.pk,
             sequential=self.version,
-            data=dumps(self.as_version)
+            raw=dumps(self.as_version)
         )
         if Diff.ACTIVE:
             old = None
@@ -67,7 +85,9 @@ class Versioned(db.Model, metaclass=BaseVersioned):
             Version.model_name == self.__class__.__name__,
             Version.model_pk == self.pk)
 
-    def load_version(self, id):
+    def load_version(self, id=None):
+        if id is None:
+            id = self.version
         return self.versions.where(Version.sequential == id).first()
 
     @property
@@ -134,7 +154,7 @@ class Version(db.Model):
     model_name = db.CharField(max_length=64)
     model_pk = db.IntegerField()
     sequential = db.IntegerField()
-    data = db.BinaryJSONField()
+    raw = db.BinaryJSONField()
 
     class Meta:
         manager = SelectQuery
@@ -147,20 +167,40 @@ class Version(db.Model):
                                                self.model_name, self.model_pk)
 
     @property
+    def data(self):
+        return json.loads(self.raw)
+
+    @property
     def as_resource(self):
-        return json.loads(self.data)
+        return {
+            'data': self.data,
+            'flags': list(self.flags.as_resource())
+        }
 
     @property
     def model(self):
         return BaseVersioned.registry[self.model_name]
 
     def load(self):
-        validator = self.model.validator(**self.as_resource)
+        validator = self.model.validator(**self.data)
         return self.model(**validator.document)
 
     @property
     def diff(self):
         return Diff.first(Diff.new == self.pk)
+
+    @flag_id_required
+    def flag(self, session=None):
+        """Flag current version with current client."""
+        if not Flag.where(Flag.version == self,
+                          Flag.client == session.client).exists():
+            Flag.create(version=self, session=session, client=session.client)
+
+    @flag_id_required
+    def unflag(self, session=None):
+        """Delete current version's flags made by current session client."""
+        Flag.delete().where(Flag.version == self,
+                            Flag.client == session.client).execute()
 
 
 class Diff(db.Model):
@@ -182,8 +222,8 @@ class Diff(db.Model):
 
     def save(self, *args, **kwargs):
         if not self.diff:
-            old = self.old.as_resource if self.old else {}
-            new = self.new.as_resource if self.new else {}
+            old = self.old.data if self.old else {}
+            new = self.new.data if self.new else {}
             self.diff = make_diff(old, new)
         super().save(*args, **kwargs)
         IdentifierRedirect.from_diff(self)
@@ -193,8 +233,8 @@ class Diff(db.Model):
         version = self.new or self.old
         return {
             'increment': self.pk,
-            'old': self.old.as_resource if self.old else None,
-            'new': self.new.as_resource if self.new else None,
+            'old': self.old.data if self.old else None,
+            'new': self.new.data if self.new else None,
             'diff': self.diff,
             'resource': version.model_name.lower(),
             'resource_pk': version.model_pk,
@@ -237,3 +277,25 @@ class IdentifierRedirect(db.Model):
         cls.update(new=new).where(cls.new == old,
                                   cls.model_name == model.__name__,
                                   cls.identifier == identifier).execute()
+
+
+class Flag(db.Model):
+    version = db.ForeignKeyField(Version, related_name='flags')
+    client = db.ForeignKeyField(Client)
+    session = db.ForeignKeyField(Session)
+    created_at = db.DateTimeField()
+
+    class Meta:
+        manager = SelectQuery
+
+    def save(self, *args, **kwargs):
+        if not self.created_at:
+            self.created_at = datetime.now()
+        super().save(*args, **kwargs)
+
+    @property
+    def as_resource(self):
+        return {
+            'at': self.created_at,
+            'by': self.client.flag_id
+        }

--- a/ban/http/resources.py
+++ b/ban/http/resources.py
@@ -172,6 +172,26 @@ class VersionnedResource(BaseCRUD):
             raise falcon.HTTPNotFound()
         resp.json(**version.as_resource)
 
+    @auth.protect  # TODO, manage scope.
+    @app.endpoint('/{identifier}/versions/{version}/flag')
+    def on_post_flag_version(self, req, resp, version, **kwargs):
+        """Flag a version."""
+        instance = self.get_object(**kwargs)
+        version = instance.load_version(version)
+        if not version:
+            raise falcon.HTTPNotFound()
+        version.flag()
+
+    @auth.protect  # TODO, manage scope.
+    @app.endpoint('/{identifier}/versions/{version}/unflag')
+    def on_post_unflag_version(self, req, resp, version, **kwargs):
+        """Unflag a version."""
+        instance = self.get_object(**kwargs)
+        version = instance.load_version(version)
+        if not version:
+            raise falcon.HTTPNotFound()
+        version.unflag()
+
 
 class Position(VersionnedResource):
     """Manipulate position resources."""

--- a/ban/tests/factories.py
+++ b/ban/tests/factories.py
@@ -37,6 +37,7 @@ class ClientFactory(BaseTestModel):
     client_secret = FuzzyText(length=54)
     redirect_uris = ['http://localhost/authorize']
     grant_type = auth_models.Client.GRANT_CLIENT_CREDENTIALS
+    flag_id = 'laposte'
 
     class Meta:
         model = auth_models.Client

--- a/ban/tests/http/test_flag.py
+++ b/ban/tests/http/test_flag.py
@@ -1,0 +1,60 @@
+import falcon
+
+from ..factories import GroupFactory
+from .utils import authorize
+
+
+@authorize
+def test_can_flag_current_version(client, url):
+    group = GroupFactory()
+    version = group.load_version()
+    uri = url('group-flag-version', identifier=group.id, version=1)
+    resp = client.post(uri)
+    assert resp.status == falcon.HTTP_200
+    assert version.flags.select().count()
+
+
+@authorize
+def test_can_unflag_current_version(client, url, session):
+    group = GroupFactory()
+    version = group.load_version()
+    version.flag()
+    assert version.flags.select().count()
+    uri = url('group-unflag-version', identifier=group.id, version=1)
+    resp = client.post(uri)
+    assert resp.status == falcon.HTTP_200
+    assert not version.flags.select().count()
+
+
+@authorize
+def test_get_version_contain_flags(client, url, session):
+    group = GroupFactory()
+    version = group.load_version()
+    version.flag()
+    uri = url('group-version', identifier=group.id, version=1)
+    resp = client.get(uri)
+    assert resp.status == falcon.HTTP_200
+    assert 'flags' in resp.json
+    assert resp.json['flags'][0]['by'] == 'laposte'
+
+
+@authorize
+def test_can_flag_past_version(client, url):
+    group = GroupFactory()
+    group.name = 'Another name'
+    group.increment_version()
+    group.save()
+    uri = url('group-flag-version', identifier=group.id, version=1)
+    resp = client.post(uri)
+    assert resp.status == falcon.HTTP_200
+    version = group.load_version(1)
+    assert version.flags.select().count()
+    version = group.load_version(2)
+    assert not version.flags.select().count()
+
+
+def test_cannot_flag_without_token(client, url):
+    group = GroupFactory()
+    uri = url('group-flag-version', identifier=group.id, version=1)
+    resp = client.post(uri)
+    assert resp.status == falcon.HTTP_401

--- a/ban/tests/http/test_group.py
+++ b/ban/tests/http/test_group.py
@@ -169,8 +169,8 @@ def test_get_group_versions(get, url):
     assert resp.status == falcon.HTTP_200
     assert len(resp.json['collection']) == 2
     assert resp.json['total'] == 2
-    assert resp.json['collection'][0]['name'] == 'Rue de la Paix'
-    assert resp.json['collection'][1]['name'] == 'Rue de la Guerre'
+    assert resp.json['collection'][0]['data']['name'] == 'Rue de la Paix'
+    assert resp.json['collection'][1]['data']['name'] == 'Rue de la Guerre'
 
 
 @authorize
@@ -182,13 +182,13 @@ def test_get_group_version(get, url):
     uri = url('group-version', identifier=street.id, version=1)
     resp = get(uri)
     assert resp.status == falcon.HTTP_200
-    assert resp.json['name'] == 'Rue de la Paix'
-    assert resp.json['version'] == 1
+    assert resp.json['data']['name'] == 'Rue de la Paix'
+    assert resp.json['data']['version'] == 1
     uri = url('group-version', identifier=street.id, version=2)
     resp = get(uri)
     assert resp.status == falcon.HTTP_200
-    assert resp.json['name'] == 'Rue de la Guerre'
-    assert resp.json['version'] == 2
+    assert resp.json['data']['name'] == 'Rue de la Guerre'
+    assert resp.json['data']['version'] == 2
 
 
 @authorize

--- a/ban/tests/http/test_municipality.py
+++ b/ban/tests/http/test_municipality.py
@@ -93,8 +93,8 @@ def test_get_municipality_versions(get, url):
     assert resp.status == falcon.HTTP_200
     assert len(resp.json['collection']) == 2
     assert resp.json['total'] == 2
-    assert resp.json['collection'][0]['name'] == 'Cabour'
-    assert resp.json['collection'][1]['name'] == 'Cabour2'
+    assert resp.json['collection'][0]['data']['name'] == 'Cabour'
+    assert resp.json['collection'][1]['data']['name'] == 'Cabour2'
 
 
 @authorize
@@ -106,13 +106,13 @@ def test_get_municipality_version(get, url):
     uri = url('municipality-version', identifier=municipality.id, version=1)
     resp = get(uri)
     assert resp.status == falcon.HTTP_200
-    assert resp.json['name'] == 'Cabour'
-    assert resp.json['version'] == 1
+    assert resp.json['data']['name'] == 'Cabour'
+    assert resp.json['data']['version'] == 1
     uri = url('municipality-version', identifier=municipality.id, version=2)
     resp = get(uri)
     assert resp.status == falcon.HTTP_200
-    assert resp.json['name'] == 'Cabour2'
-    assert resp.json['version'] == 2
+    assert resp.json['data']['name'] == 'Cabour2'
+    assert resp.json['data']['version'] == 2
 
 
 @authorize

--- a/ban/tests/http/utils.py
+++ b/ban/tests/http/utils.py
@@ -7,7 +7,10 @@ def authorize(func):
 
     @wraps(func)
     def inner(*args, **kwargs):
-        token = TokenFactory()
+        token_kwargs = {}
+        if 'session' in kwargs:
+            token_kwargs['session'] = kwargs['session']
+        token = TokenFactory(**token_kwargs)
 
         def attach(kwargs):
             kwargs['headers']['Authorization'] = 'Bearer {}'.format(token.access_token)  # noqa

--- a/ban/tests/test_flags.py
+++ b/ban/tests/test_flags.py
@@ -1,0 +1,82 @@
+import pytest
+
+from ban.core import context
+
+from .factories import GroupFactory, SessionFactory
+
+
+def test_can_flag_current_version(session):
+    group = GroupFactory()
+    version = group.load_version()
+    version.flag()
+    assert version.flags.select().count()
+
+
+def test_cannot_duplicate_flag(session):
+    group = GroupFactory()
+    version = group.load_version()
+    version.flag()
+    version.flag()
+    assert version.flags.select().count() == 1
+
+
+def test_can_flag_past_version(session):
+    group = GroupFactory()
+    group.name = 'Another name'
+    group.increment_version()
+    group.save()
+    version = group.load_version(1)
+    version.flag()
+    assert version.flags.select().count()
+    version = group.load_version(2)
+    assert not version.flags.select().count()
+
+
+def test_can_unflag_current_version(session):
+    group = GroupFactory()
+    version = group.load_version()
+    version.flag()
+    assert version.flags.select().count()
+    version.unflag()
+    assert not version.flags.select().count()
+
+
+def test_cannot_unflag_other_client_flag(session):
+    group = GroupFactory()
+    version = group.load_version()
+    version.flag()
+    # Change current session
+    session = SessionFactory()
+    context.set('session', session)
+    assert version.flags.select().count() == 1
+    version.unflag()
+    assert version.flags.select().count() == 1
+
+
+def test_cannot_flag_without_session():
+    group = GroupFactory()
+    with pytest.raises(ValueError):
+        group.load_version().flag()
+
+
+def test_cannot_flag_if_session_has_no_client(session):
+    group = GroupFactory()
+    session.client = None
+    with pytest.raises(ValueError):
+        group.load_version().flag()
+
+
+def test_cannot_flag_if_session_client_has_no_flag_id(session):
+    group = GroupFactory()
+    session.client.flag_id = None
+    with pytest.raises(ValueError):
+        group.load_version().flag()
+
+
+def test_version_flags_attribute_returns_flags(session):
+    group = GroupFactory()
+    group.load_version().flag()
+    version = group.load_version()
+    assert version.flags.count()
+    flag = version.flags[0]
+    assert flag.created_at


### PR DESCRIPTION
Une première gestion des "tampons":

- un model `Flag` qui a une FK vers version
- l'ajout de la propriété `flag_id` au model `Client`; seules valeurs autorisés en l'état: `'ign', 'laposte', 'local_authority'`
- seuls les Client avec un `flag_id` peuvent tamponner
- un nouveau endpoint sur n'importe quel resource permettant de tamponner une resource: `/resource/{id}/version/{numero}/flag`
- un nouveau endpoint sur n'importe quel resource permettant de détamponner une resource: `/resource/{id}/version/{numero}/unflag` (ne supprime que les tampons éventuels du client de la session)
- ajout des flags dans la réponse d'une version