### PR TITLE
Field level conflict management

### DIFF
--- a/ban/auth/models.py
+++ b/ban/auth/models.py
@@ -102,6 +102,18 @@ class Session(db.Model):
     ip = db.CharField(null=True)  # TODO IPField
     email = db.CharField(null=True)  # TODO EmailField
 
+    @property
+    def as_relation(self):
+        # Pretend to be a resource for created_by/modified_by values in
+        # resources serialization.
+        return self.pk
+
+    @property
+    def id(self):
+        # Pretend to be a resource for created_by/modified_by values in
+        # list resources serialization.
+        return self.pk
+
 
 class Token(db.Model):
     session = db.ForeignKeyField(Session)

--- a/ban/core/models.py
+++ b/ban/core/models.py
@@ -31,6 +31,14 @@ class Model(ResourceModel, Versioned, metaclass=BaseModel):
         resource_schema = {'version': {'required': False},
                            'id': {'required': False}}
 
+    @classmethod
+    def validate(cls, validator, document, instance):
+        errors = {}
+        # Only check version if instance already exists.
+        if instance and not document.get('version'):
+            errors['version'] = validator.ERROR_REQUIRED_FIELD
+        return errors
+
 
 class NamedModel(Model):
     name = db.CharField(max_length=200)
@@ -163,7 +171,8 @@ class HouseNumber(Model):
     @property
     def center(self):
         position = self.position_set.first()
-        return position.center.geojson if position else None
+        return (position.center.geojson
+                if position and position.center else None)
 
     @property
     def ancestors_resource(self):
@@ -209,9 +218,10 @@ class Position(Model):
     )
 
     resource_fields = ['center', 'source', 'housenumber', 'kind', 'comment',
-                       'parent', 'positioning']
+                       'parent', 'positioning', 'name']
 
-    center = db.PointField(verbose_name=_("center"))
+    name = db.CharField(max_length=200, null=True)
+    center = db.PointField(verbose_name=_("center"), null=True)
     housenumber = db.ForeignKeyField(HouseNumber)
     parent = db.ForeignKeyField('self', related_name='children', null=True)
     source = db.CharField(max_length=64, null=True)
@@ -224,6 +234,17 @@ class Position(Model):
 
     @property
     def center_resource(self):
+        if not self.center:
+            return None
         if not isinstance(self.center, Point):
             self.center = Point(*self.center)
         return self.center.geojson
+
+    @classmethod
+    def validate(cls, validator, document, instance):
+        errors = super().validate(validator, document, instance)
+        if not document.get('name') and not document.get('center'):
+            msg = 'A position must have either a center or a name.'
+            errors['center'] = msg
+            errors['name'] = msg
+        return errors

--- a/ban/core/resource.py
+++ b/ban/core/resource.py
@@ -10,6 +10,7 @@ from postgis import Point
 class ResourceValidator(Validator):
 
     ValidationError = ValidationError
+    ERROR_REQUIRED_FIELD = errors.ERROR_REQUIRED_FIELD
 
     def __init__(self, model, *args, **kwargs):
         self.model = model
@@ -41,9 +42,10 @@ class ResourceValidator(Validator):
     def validate(self, data, instance=None, **kwargs):
         self.instance = instance
         super().validate(data, **kwargs)
-        if ('version' in self.schema and instance
-           and not self.document.get('version')):
-            self._error('version', errors.ERROR_REQUIRED_FIELD)
+        if hasattr(self.model, 'validate'):
+            for key, message in self.model.validate(self, self.document,
+                                                    instance).items():
+                self._error(key, message)
 
     def save(self):
         if self.errors:

--- a/ban/core/resource.py
+++ b/ban/core/resource.py
@@ -1,76 +1,10 @@
 import uuid
 
 import peewee
-from cerberus import ValidationError, Validator, errors
 
 from ban import db
-from postgis import Point
 
-
-class ResourceValidator(Validator):
-
-    ValidationError = ValidationError
-    ERROR_REQUIRED_FIELD = errors.ERROR_REQUIRED_FIELD
-
-    def __init__(self, model, *args, **kwargs):
-        self.model = model
-        kwargs['purge_unknown'] = True
-        super().__init__(model._meta.resource_schema, *args, **kwargs)
-
-    def _validate_type_point(self, field, value):
-        if not isinstance(value, (str, list, tuple, Point)):
-            self._error(field, 'Invalid Point: {}'.format(value))
-
-    def _validate_unique(self, unique, field, value):
-        qs = self.model.select()
-        attr = getattr(self.model, field)
-        qs = qs.where(attr == value)
-        if self.instance:
-            qs = qs.where(self.model.pk != self.instance.pk)
-        if qs.exists():
-            self._error(field, 'Duplicate value for {}: {}'.format(field,
-                                                                   value))
-
-    def _validate_coerce(self, coerce, field, value):
-        # See https://github.com/nicolaiarocci/cerberus/issues/171.
-        try:
-            value = coerce(value)
-        except (TypeError, ValueError, peewee.DoesNotExist):
-            self._error(field, errors.ERROR_COERCION_FAILED.format(field))
-        return value
-
-    def validate(self, data, instance=None, **kwargs):
-        self.instance = instance
-        super().validate(data, **kwargs)
-        if hasattr(self.model, 'validate'):
-            for key, message in self.model.validate(self, self.document,
-                                                    instance).items():
-                self._error(key, message)
-
-    def save(self):
-        if self.errors:
-            raise ValidationError('Invalid document')
-        database = self.model._meta.database
-        if self.instance:
-            with database.atomic():
-                for key, value in self.document.items():
-                    setattr(self.instance, key, value)
-                self.instance.save()
-        else:
-            with database.atomic():
-                m2m = {}
-                data = {}
-                for key, value in self.document.items():
-                    field = getattr(self.model, key)
-                    if isinstance(field, db.ManyToManyField):
-                        m2m[key] = value
-                    else:
-                        data[key] = value
-                self.instance = self.model.create(**data)
-                # m2m need the instance to be saved.
-                for key, value in m2m.items():
-                    setattr(self.instance, key, value)
-        return self.instance
+from .validators import ResourceValidator
 
 
 class ResourceQueryResultWrapper(peewee.ModelQueryResultWrapper):
@@ -113,31 +47,36 @@ class BaseResource(peewee.BaseModel):
     def __new__(mcs, name, bases, attrs, **kwargs):
         # Inherit and extend instead of replacing.
         resource_fields = attrs.pop('resource_fields', None)
+        resource_schema = attrs.pop('resource_schema', None)
         cls = super().__new__(mcs, name, bases, attrs, **kwargs)
         if resource_fields is not None:
-            inherited = getattr(cls, 'resource_fields', None)
-            if inherited:
-                resource_fields.extend(inherited)
+            inherited = getattr(cls, 'resource_fields', {})
+            resource_fields.extend(inherited)
             cls.resource_fields = resource_fields
+        if resource_schema is not None:
+            inherited = getattr(cls, 'resource_schema', {})
+            resource_schema.update(inherited)
+            cls.resource_schema = resource_schema
         cls.fields_for_resource = cls.resource_fields
         cls.fields_for_relation = [
             n for n in cls.fields_for_resource
             if mcs.include_field_for_relation(cls, n)]
         cls.fields_for_list = cls.fields_for_relation + ['resource']
-        cls._meta.resource_schema = cls.build_resource_schema()
+        cls.build_resource_schema()
         return cls
 
 
 class ResourceModel(db.Model, metaclass=BaseResource):
     resource_fields = ['id']
     identifiers = []
+    resource_schema = {'id': {'readonly': True}}
 
     id = db.CharField(max_length=50, unique=True, null=False)
 
     class Meta:
         abstract = True
-        resource_schema = {'id': {'required': False}}
         manager = SelectQuery
+        validator = ResourceValidator
 
     @classmethod
     def make_id(cls):
@@ -150,7 +89,8 @@ class ResourceModel(db.Model, metaclass=BaseResource):
 
     @classmethod
     def build_resource_schema(cls):
-        schema = {}
+        """Map Peewee models to Cerberus validation schema."""
+        schema = dict(cls.resource_schema)
         for name, field in cls._meta.fields.items():
             if name not in cls.fields_for_resource:
                 continue
@@ -175,13 +115,15 @@ class ResourceModel(db.Model, metaclass=BaseResource):
                 row['empty'] = False
             if getattr(field, 'choices', None):
                 row['allowed'] = [v for v, l in field.choices]
-            row.update(cls._meta.resource_schema.get(name, {}))
+            row.update(cls.resource_schema.get(name, {}))
             schema[name] = row
-        return schema
+            if schema[name].get('readonly'):
+                schema[name]['required'] = False
+        cls.resource_schema = schema
 
     @classmethod
     def validator(cls, instance=None, update=False, **data):
-        validator = ResourceValidator(cls)
+        validator = cls._meta.validator(cls)
         validator(data, update=update, instance=instance)
         return validator
 

--- a/ban/core/validators.py
+++ b/ban/core/validators.py
@@ -1,0 +1,107 @@
+from cerberus import ValidationError, Validator, errors
+import peewee
+from postgis import Point
+
+from ban import db
+from ban.utils import make_diff
+
+
+class ResourceValidator(Validator):
+
+    ValidationError = ValidationError
+    ERROR_REQUIRED_FIELD = errors.ERROR_REQUIRED_FIELD
+
+    def __init__(self, model, *args, **kwargs):
+        self.model = model
+        kwargs['purge_unknown'] = True
+        super().__init__(model.resource_schema, *args, **kwargs)
+
+    def _validate_type_point(self, field, value):
+        if not isinstance(value, (str, list, tuple, Point)):
+            self._error(field, 'Invalid Point: {}'.format(value))
+
+    def _validate_unique(self, unique, field, value):
+        qs = self.model.select()
+        attr = getattr(self.model, field)
+        qs = qs.where(attr == value)
+        if self.instance:
+            qs = qs.where(self.model.pk != self.instance.pk)
+        if qs.exists():
+            self._error(field, 'Duplicate value for {}: {}'.format(field,
+                                                                   value))
+
+    def _validate_coerce(self, coerce, field, value):
+        # See https://github.com/nicolaiarocci/cerberus/issues/171.
+        try:
+            value = coerce(value)
+        except (TypeError, ValueError, peewee.DoesNotExist):
+            self._error(field, errors.ERROR_COERCION_FAILED.format(field))
+        return value
+
+    def _purge_readonly(self, data):
+        # cf https://github.com/nicolaiarocci/cerberus/issues/240.
+        for key in tuple(data):
+            if self.schema.get(key, {}).get('readonly'):
+                del data[key]
+
+    def validate(self, data, instance=None, **kwargs):
+        self.instance = instance
+        self._purge_readonly(data)
+        super().validate(data, **kwargs)
+        if hasattr(self.model, 'validate'):
+            for key, message in self.model.validate(self, self.document,
+                                                    instance).items():
+                self._error(key, message)
+
+    def patch(self):
+        for key, value in self.document.items():
+            setattr(self.instance, key, value)
+
+    def save(self):
+        if self.errors:
+            raise ValidationError('Invalid document')
+        database = self.model._meta.database
+        if self.instance:
+            with database.atomic():
+                self.patch()
+                self.instance.save()
+        else:
+            with database.atomic():
+                m2m = {}
+                data = {}
+                for key, value in self.document.items():
+                    field = getattr(self.model, key)
+                    if isinstance(field, db.ManyToManyField):
+                        m2m[key] = value
+                    else:
+                        data[key] = value
+                self.instance = self.model.create(**data)
+                # m2m need the instance to be saved.
+                for key, value in m2m.items():
+                    setattr(self.instance, key, value)
+        return self.instance
+
+
+class VersionedResourceValidator(ResourceValidator):
+
+    def patch(self):
+        # Let's try to be smart and patch object if claimed version does not
+        # match with expected but not conflict is detected.
+        claimed_version = max(1, self.document.get('version', 1))
+        current_version = self.instance.version if self.instance else 0
+        if self.instance and claimed_version <= current_version > 1:
+            base = self.instance.load_version(claimed_version - 1)
+            current = self.instance.load_version(current_version)
+            diff = make_diff(base.as_resource, current.as_resource)
+            # Those are keys changed between that last know version of the
+            # client and the current version we have.
+            protected = diff.keys()
+            diff = make_diff(base.as_resource, self.document,
+                             update=self.update)
+            conflict = any(k in protected for k in diff.keys())
+            if not conflict:
+                for key in diff.keys():
+                    setattr(self.instance, key, self.document.get(key))
+                self.instance.increment_version()
+                return
+        super().patch()

--- a/ban/db/fields.py
+++ b/ban/db/fields.py
@@ -78,7 +78,10 @@ class ForeignKeyField(peewee.ForeignKeyField):
     def coerce(self, value):
         if isinstance(value, peewee.Model):
             value = value.pk
-        elif isinstance(value, str) and hasattr(self.rel_model, 'coerce'):
+        elif isinstance(value, dict):
+            # We have a resource dict.
+            value = value['id']
+        if isinstance(value, str) and hasattr(self.rel_model, 'coerce'):
             value = self.rel_model.coerce(value).pk
         return super().coerce(value)
 
@@ -128,7 +131,7 @@ class ArrayField(postgres_ext.ArrayField):
 
 
 class DateTimeField(peewee.DateTimeField):
-    pass
+    schema_type = 'datetime'
 
 
 class BooleanField(peewee.BooleanField):

--- a/ban/tests/commands/test_commands.py
+++ b/ban/tests/commands/test_commands.py
@@ -7,6 +7,7 @@ from ban.commands.db import truncate
 from ban.commands.export import resources
 from ban.commands.importer import municipalities
 from ban.core import models
+from ban.core.encoder import dumps
 from ban.core.versioning import Diff
 from ban.tests import factories
 
@@ -116,13 +117,13 @@ def test_export_resources():
     factories.PositionFactory(housenumber=hn)
     path = Path(__file__).parent / 'data/export.sjson'
     resources(path)
+
     with path.open() as f:
         lines = f.readlines()
         assert len(lines) == 3
-        assert json.loads(lines[0]) == mun.as_list
-        assert json.loads(lines[1]) == street.as_list
-        resource = hn.as_list
-        # JSON transform internals tuples to lists.
-        resource['center']['coordinates'] = list(resource['center']['coordinates'])  # noqa
-        assert json.loads(lines[2]) == resource
+        # loads/dumps to compare string dates to string dates.
+        assert json.loads(lines[0]) == json.loads(dumps(mun.as_list))
+        assert json.loads(lines[1]) == json.loads(dumps(street.as_list))
+        # Plus, JSON transform internals tuples to lists.
+        assert json.loads(lines[2]) == json.loads(dumps(hn.as_list))
     path.unlink()

--- a/ban/tests/http/test_diff.py
+++ b/ban/tests/http/test_diff.py
@@ -28,15 +28,12 @@ def test_diff_endpoint(client):
     assert len(diffs) == 7
     street_create_diff = diffs[1]
     assert street_create_diff['increment'] == diffs[0]['increment'] + 1
-    assert street_create_diff['old'] == None
-    assert street_create_diff['new']['pk'] == street.pk
+    assert street_create_diff['old'] is None
     assert street_create_diff['new']['id'] == street.id
     assert street_create_diff['resource_pk'] == street.pk
     street_update_diff = diffs[-1]
     assert street_update_diff['old']['id'] == street.id
-    assert street_update_diff['old']['pk'] == street.pk
     assert street_update_diff['new']['id'] == street.id
-    assert street_update_diff['new']['pk'] == street.pk
     assert street_update_diff['diff']['name'] == {
         "old": old_street_name,
         "new": "Rue des Musiciens"

--- a/ban/tests/http/test_group.py
+++ b/ban/tests/http/test_group.py
@@ -2,6 +2,7 @@ import json
 
 import falcon
 from ban.core import models
+from ban.core.encoder import dumps
 
 from ..factories import HouseNumberFactory, MunicipalityFactory, GroupFactory
 from .utils import authorize
@@ -43,9 +44,10 @@ def test_get_group_housenumbers(get, url):
     resp = get(url('group-housenumbers', identifier=street.id))
     assert resp.status == falcon.HTTP_200
     assert resp.json['total'] == 3
-    assert resp.json['collection'][0] == hn1.as_list
-    assert resp.json['collection'][1] == hn2.as_list
-    assert resp.json['collection'][2] == hn3.as_list
+    # loads/dumps to compare string dates to string dates.
+    assert resp.json['collection'][0] == json.loads(dumps(hn1.as_list))
+    assert resp.json['collection'][1] == json.loads(dumps(hn2.as_list))
+    assert resp.json['collection'][2] == json.loads(dumps(hn3.as_list))
 
 
 @authorize

--- a/ban/tests/http/test_municipality.py
+++ b/ban/tests/http/test_municipality.py
@@ -2,6 +2,7 @@ import json
 
 import falcon
 from ban.core import models
+from ban.core.encoder import dumps
 
 from ..factories import MunicipalityFactory, PostCodeFactory, GroupFactory
 from .utils import authorize
@@ -42,7 +43,8 @@ def test_get_municipality_groups_collection(get, url):
     uri = url('municipality-groups', identifier=municipality.id)
     resp = get(uri, query_string='pouet=ah')
     assert resp.status == falcon.HTTP_200
-    assert resp.json['collection'][0] == street.as_list
+    # loads/dumps to compare date strings to date strings.
+    assert resp.json['collection'][0] == json.loads(dumps(street.as_list))
     assert resp.json['total'] == 1
 
 

--- a/ban/tests/http/test_position.py
+++ b/ban/tests/http/test_position.py
@@ -100,6 +100,7 @@ def test_cannot_create_position_without_center_and_name(client):
     resp = client.post(url, data)
     assert resp.status == falcon.HTTP_422
     assert 'center' in resp.json['errors']
+    assert 'name' in resp.json['errors']
 
 
 @authorize
@@ -361,7 +362,8 @@ def test_cannot_remove_center_and_name(client, url):
     }
     resp = client.patch(uri, body=json.dumps(data))
     assert resp.status == falcon.HTTP_422
-    assert "center" in resp.json['errors']
+    assert "center" in resp.json["errors"]
+    assert "name" in resp.json["errors"]
 
 
 @authorize

--- a/ban/tests/test_models.py
+++ b/ban/tests/test_models.py
@@ -203,7 +203,11 @@ def test_group_as_list():
         'name': 'Rue des Fleurs',
         'resource': 'group',
         'attributes': None,
-        'laposte': None
+        'laposte': None,
+        'created_at': street.created_at,
+        'created_by': street.created_by.pk,
+        'modified_at': street.modified_at,
+        'modified_by': street.modified_by.pk,
     }
 
 
@@ -330,7 +334,11 @@ def test_housenumber_as_resource():
         'id': housenumber.id,
         'number': '90',
         'postcode': None,
-        'ordinal': 'bis'
+        'ordinal': 'bis',
+        'created_by': housenumber.created_by.pk,
+        'created_at': housenumber.created_at,
+        'modified_by': housenumber.modified_by.pk,
+        'modified_at': housenumber.modified_at,
     }
 
 
@@ -345,8 +353,8 @@ def test_position_is_versioned():
     assert len(position.versions) == 2
     version1 = position.versions[0].load()
     version2 = position.versions[1].load()
-    assert version1.center == {'type': 'Point', 'coordinates': [1, 2]}
-    assert version2.center == {'type': 'Point', 'coordinates': [3, 4]}
+    assert version1.center.geojson == {'type': 'Point', 'coordinates': (1, 2)}
+    assert version2.center.geojson == {'type': 'Point', 'coordinates': (3, 4)}
     assert version2.housenumber == housenumber
 
 
@@ -385,3 +393,5 @@ def test_position_center_coerce(given, expected):
     center = models.Position.get(models.Position.id == position.id).center
     if given:
         assert center.coords == expected
+    else:
+        assert not center

--- a/ban/tests/test_models.py
+++ b/ban/tests/test_models.py
@@ -265,6 +265,12 @@ def test_housenumber_center_without_position():
     assert housenumber.center is None
 
 
+def test_housenumber_center_with_position_without_center():
+    housenumber = HouseNumberFactory()
+    PositionFactory(housenumber=housenumber, name="bâtiment A", center=None)
+    assert housenumber.center is None
+
+
 def test_create_housenumber_with_district():
     municipality = MunicipalityFactory()
     district = GroupFactory(municipality=municipality, kind=models.Group.AREA)
@@ -371,8 +377,11 @@ def test_get_instantiate_object_properly():
     ((1.123456789, 2.987654321), (1.123456789, 2.987654321)),
     ([1, 2], (1, 2)),
     ("(1, 2)", (1, 2)),
+    (None, None),
+    ("", None),
 ])
 def test_position_center_coerce(given, expected):
-    position = PositionFactory(center=given)
+    position = PositionFactory(center=given, name="bâtiment Z")
     center = models.Position.get(models.Position.id == position.id).center
-    assert center.coords == expected
+    if given:
+        assert center.coords == expected

--- a/ban/utils.py
+++ b/ban/utils.py
@@ -19,3 +19,25 @@ def is_uuid4(uuid_string):
 def compute_cia(insee, fantoir, number=None, ordinal=None):
     return '_'.join([insee, fantoir, (number or '').upper(),
                      (ordinal or '').upper()])
+
+
+def make_diff(old, new, update=False):
+    """Create a diff between two versions of the same resource.
+
+    update      only consider new keys"""
+    meta = set(['pk', 'id', 'created_by', 'modified_by', 'created_at',
+                'modified_at', 'version', 'cia'])
+    keys = list(new)
+    if not update:
+        keys += list(old)
+    keys = set(keys) - meta
+    diff = {}
+    for key in keys:
+        old_value = old.get(key)
+        new_value = new.get(key)
+        if new_value != old_value:
+            diff[key] = {
+                'old': str(old_value),
+                'new': str(new_value)
+            }
+    return diff


### PR DESCRIPTION
Adds field by field conflict management.
The normal scenario when pushing data to the API is to give the version number we are creating.
For example: we take a resource from the API, say version 3. Now we make modification, then we can post back a new version to the API, but we need to increment the version to 4.
Until now, if we received any other version number than 4 in this scenario, we raise a 409 Conflict.
Now we try to be more smart: we look at the claimed version. If possible, we make a diff between the claimed version and the claimed version - 1. So that should be the changed data by the user. Now, we check if this data has been changed since the claimed version - 1 and the current real version.
If nothing conflicts, then we can proceed and save.

To do so, I've refactored the way we build versions and diffs, and used proper resource serializing instead of a dedicated serialization.
This PR also adds `created_*`/`modified_*` fields into the resource serialization.
Also, note that this PR includes the #109.