### PR TITLE
Add Version.period field, and allow to requests version by date

### DIFF
--- a/ban/core/versioning.py
+++ b/ban/core/versioning.py
@@ -72,17 +72,18 @@ class Versioned(db.Model, metaclass=BaseVersioned):
             sequential=self.version,
             raw=dumps(self.as_version)
         )
+        old = None
+        if self.version > 1:
+            old = self.load_version(self.version - 1)
+            old.close_period(new.period[0])
         if Diff.ACTIVE:
-            old = None
-            if self.version > 1:
-                old = self.load_version(self.version - 1)
             Diff.create(old=old, new=new, created_at=self.modified_at)
 
     @property
     def versions(self):
         return Version.select().where(
             Version.model_name == self.__class__.__name__,
-            Version.model_pk == self.pk)
+            Version.model_pk == self.pk).order_by(Version.sequential)
 
     def load_version(self, id=None):
         if id is None:
@@ -154,6 +155,7 @@ class Version(db.Model):
     model_pk = db.IntegerField()
     sequential = db.IntegerField()
     raw = db.BinaryJSONField()
+    period = db.DateRangeField()
 
     class Meta:
         manager = SelectQuery
@@ -200,6 +202,16 @@ class Version(db.Model):
         """Delete current version's flags made by current session client."""
         Flag.delete().where(Flag.version == self,
                             Flag.client == session.client).execute()
+
+    def save(self, *args, **kwargs):
+        if not self.pk:
+            self.period = [datetime.now(), None]
+        return super().save(*args, **kwargs)
+
+    def close_period(self, bound):
+        # DateTimeRange is immutable, so create new one.
+        self.period = [self.period.lower, bound]
+        self.save()
 
 
 class Diff(db.Model):

--- a/ban/core/versioning.py
+++ b/ban/core/versioning.py
@@ -85,10 +85,15 @@ class Versioned(db.Model, metaclass=BaseVersioned):
             Version.model_name == self.__class__.__name__,
             Version.model_pk == self.pk).order_by(Version.sequential)
 
-    def load_version(self, id=None):
-        if id is None:
-            id = self.version
-        return self.versions.where(Version.sequential == id).first()
+    def load_version(self, ref=None):
+        qs = self.versions
+        if ref is None:
+            ref = self.version
+        if isinstance(ref, datetime):
+            qs = qs.where(Version.period.contains(ref))
+        else:
+            qs = qs.where(Version.sequential == ref)
+        return qs.first()
 
     @property
     def locked_version(self):

--- a/ban/tests/http/test_flag.py
+++ b/ban/tests/http/test_flag.py
@@ -8,7 +8,7 @@ from .utils import authorize
 def test_can_flag_current_version(client, url):
     group = GroupFactory()
     version = group.load_version()
-    uri = url('group-flag-version', identifier=group.id, version=1)
+    uri = url('group-flag-version', identifier=group.id, ref=1)
     resp = client.post(uri)
     assert resp.status == falcon.HTTP_200
     assert version.flags.select().count()
@@ -20,7 +20,7 @@ def test_can_unflag_current_version(client, url, session):
     version = group.load_version()
     version.flag()
     assert version.flags.select().count()
-    uri = url('group-unflag-version', identifier=group.id, version=1)
+    uri = url('group-unflag-version', identifier=group.id, ref=1)
     resp = client.post(uri)
     assert resp.status == falcon.HTTP_200
     assert not version.flags.select().count()
@@ -31,7 +31,7 @@ def test_get_version_contain_flags(client, url, session):
     group = GroupFactory()
     version = group.load_version()
     version.flag()
-    uri = url('group-version', identifier=group.id, version=1)
+    uri = url('group-version', identifier=group.id, ref=1)
     resp = client.get(uri)
     assert resp.status == falcon.HTTP_200
     assert 'flags' in resp.json
@@ -44,7 +44,7 @@ def test_can_flag_past_version(client, url):
     group.name = 'Another name'
     group.increment_version()
     group.save()
-    uri = url('group-flag-version', identifier=group.id, version=1)
+    uri = url('group-flag-version', identifier=group.id, ref=1)
     resp = client.post(uri)
     assert resp.status == falcon.HTTP_200
     version = group.load_version(1)
@@ -55,6 +55,6 @@ def test_can_flag_past_version(client, url):
 
 def test_cannot_flag_without_token(client, url):
     group = GroupFactory()
-    uri = url('group-flag-version', identifier=group.id, version=1)
+    uri = url('group-flag-version', identifier=group.id, ref=1)
     resp = client.post(uri)
     assert resp.status == falcon.HTTP_401

--- a/ban/tests/http/test_group.py
+++ b/ban/tests/http/test_group.py
@@ -179,12 +179,12 @@ def test_get_group_version(get, url):
     street.version = 2
     street.name = "Rue de la Guerre"
     street.save()
-    uri = url('group-version', identifier=street.id, version=1)
+    uri = url('group-version', identifier=street.id, ref=1)
     resp = get(uri)
     assert resp.status == falcon.HTTP_200
     assert resp.json['data']['name'] == 'Rue de la Paix'
     assert resp.json['data']['version'] == 1
-    uri = url('group-version', identifier=street.id, version=2)
+    uri = url('group-version', identifier=street.id, ref=2)
     resp = get(uri)
     assert resp.status == falcon.HTTP_200
     assert resp.json['data']['name'] == 'Rue de la Guerre'
@@ -194,7 +194,7 @@ def test_get_group_version(get, url):
 @authorize
 def test_get_group_unknown_version_should_go_in_404(get, url):
     street = GroupFactory(name="Rue de la Paix")
-    uri = url('group-version', identifier=street.id, version=2)
+    uri = url('group-version', identifier=street.id, ref=2)
     resp = get(uri)
     assert resp.status == falcon.HTTP_404
 

--- a/ban/tests/http/test_municipality.py
+++ b/ban/tests/http/test_municipality.py
@@ -1,8 +1,10 @@
 import json
+from datetime import datetime
 
 import falcon
 from ban.core import models
 from ban.core.encoder import dumps
+from ban.core.versioning import Version
 
 from ..factories import MunicipalityFactory, PostCodeFactory, GroupFactory
 from .utils import authorize
@@ -95,6 +97,55 @@ def test_get_municipality_versions(get, url):
     assert resp.json['total'] == 2
     assert resp.json['collection'][0]['data']['name'] == 'Cabour'
     assert resp.json['collection'][1]['data']['name'] == 'Cabour2'
+
+
+@authorize
+def test_get_municipality_versions_by_datetime(get, url):
+    municipality = MunicipalityFactory(name="Cabour")
+    municipality.version = 2
+    municipality.name = "Cabour2"
+    municipality.save()
+    # Artificialy change versions periods.
+    period = [datetime(2015, 1, 1), datetime(2016, 1, 1)]
+    Version.update(period=period).where(Version.sequential == 1).execute()
+    period = [datetime(2016, 1, 1), None]
+    Version.update(period=period).where(Version.sequential == 2).execute()
+    uri = url('municipality-versions', identifier=municipality.id)
+    # Should work with a simple datetime.
+    resp = get(uri, query_string={'at': '2015-06-01 01:02:03'})
+    assert resp.status == falcon.HTTP_200
+    assert len(resp.json['collection']) == 1
+    assert resp.json['total'] == 1
+    assert resp.json['collection'][0]['data']['name'] == 'Cabour'
+    # Should work with a simple date too.
+    resp = get(uri, query_string={'at': '2015-06-01 00:00:00'})
+    assert resp.status == falcon.HTTP_200
+    assert len(resp.json['collection']) == 1
+    assert resp.json['total'] == 1
+    assert resp.json['collection'][0]['data']['name'] == 'Cabour'
+    # Now ask in the range of the second version
+    resp = get(uri, query_string={'at': '2016-06-01'})
+    assert resp.status == falcon.HTTP_200
+    assert len(resp.json['collection']) == 1
+    assert resp.json['total'] == 1
+    assert resp.json['collection'][0]['data']['name'] == 'Cabour2'
+    # Asking for the common bound should only return the new version.
+    resp = get(uri, query_string={'at': '2016-01-01 00:00:00'})
+    assert resp.status == falcon.HTTP_200
+    assert len(resp.json['collection']) == 1
+    assert resp.json['total'] == 1
+    assert resp.json['collection'][0]['data']['name'] == 'Cabour2'
+
+
+@authorize
+def test_get_versions_by_datetime_should_raise_if_format_is_invalid(get, url):
+    municipality = MunicipalityFactory(name="Cabour")
+    # Artificialy change versions periods.
+    uri = url('municipality-versions', identifier=municipality.id)
+    # Should work with a simple datetime.
+    resp = get(uri, query_string={'at': '01:02:03 2015-06-01'})
+    assert resp.status == falcon.HTTP_400
+    assert 'Valid formats' in resp.json['description']
 
 
 @authorize

--- a/ban/tests/test_models.py
+++ b/ban/tests/test_models.py
@@ -52,9 +52,12 @@ def test_municipality_is_versioned():
     municipality.increment_version()
     municipality.save()
     assert municipality.version == 2
-    assert len(municipality.versions) == 2
-    version1 = municipality.versions[0].load()
-    version2 = municipality.versions[1].load()
+    versions = municipality.versions
+    assert len(versions) == 2
+    version1 = versions[0].load()
+    version2 = versions[1].load()
+    assert versions[0].period.upper == versions[1].period.lower
+    assert versions[1].period.upper is None
     assert version1.name == "Moret-sur-Loing"
     assert version2.name == "Orvanne"
     assert municipality.versions[0].diff
@@ -64,10 +67,14 @@ def test_municipality_is_versioned():
     municipality.insee = "77316"
     municipality.increment_version()
     municipality.save()
-    assert len(municipality.versions) == 3
-    diff = municipality.versions[2].diff
-    assert diff.old == municipality.versions[1]
-    assert diff.new == municipality.versions[2]
+    versions = municipality.versions
+    assert len(versions) == 3
+    diff = versions[2].diff
+    assert diff.old == versions[1]
+    assert diff.new == versions[2]
+    assert versions[0].period.upper == versions[1].period.lower
+    assert versions[1].period.upper == versions[2].period.lower
+    assert versions[2].period.upper is None
 
 
 def test_municipality_diff_contain_only_changed_data():


### PR DESCRIPTION
Fix #145

- adds a `period` field of type `DateTimeField` (psql `tsrange`) to `Version` model
- allow to pass a date or datetime instead of a `sequential` reference to get the version of a resource