### PR TITLE
Use our error message when raising from Field.coerce

### DIFF
--- a/ban/core/exceptions.py
+++ b/ban/core/exceptions.py
@@ -1,3 +1,7 @@
+class ValidationError(ValueError):
+    ...
+
+
 class RedirectError(ValueError):
 
     def __init__(self, identifier, value, redirect):

--- a/ban/core/validators.py
+++ b/ban/core/validators.py
@@ -2,7 +2,7 @@ import peewee
 
 from ban import db
 from ban.utils import make_diff
-from .exceptions import RedirectError, MultipleRedirectsError
+from .exceptions import RedirectError, MultipleRedirectsError, ValidationError
 
 
 class ResourceValidator:
@@ -44,6 +44,10 @@ class ResourceValidator:
             value = field.coerce(value)
         except (RedirectError, MultipleRedirectsError) as e:
             raise ValueError(e)
+        except ValidationError:
+            # Those are error messages created by us, we want them instead of
+            # the default coerce one.
+            raise
         except (ValueError, TypeError):
             raise ValueError('Unable to coerce value "{}"'.format(value))
         except peewee.DoesNotExist:

--- a/ban/db/fields.py
+++ b/ban/db/fields.py
@@ -9,6 +9,8 @@ from playhouse.fields import PasswordField as PWDField
 from postgis import Point
 from psycopg2.extras import DateTimeTZRange
 
+from ban.core.exceptions import ValidationError
+
 __all__ = ['PointField', 'ForeignKeyField', 'CharField', 'IntegerField',
            'HStoreField', 'UUIDField', 'ArrayField', 'DateTimeField',
            'BooleanField', 'BinaryJSONField', 'PostCodeField', 'FantoirField',
@@ -210,7 +212,7 @@ class PostCodeField(CharField):
     def coerce(self, value):
         value = str(value)
         if not len(value) == 5 or not value.isdigit():
-            raise ValueError('Invalid postcode "{}"'.format(value))
+            raise ValidationError('Invalid postcode: "{}"'.format(value))
         return value
 
 
@@ -225,8 +227,9 @@ class FantoirField(CharField):
         if len(value) == 10:
             value = value[:9]
         if not len(value) == 9:
-            raise ValueError('FANTOIR must be municipality INSEE '
-                             '+ 4 first chars of FANTOIR "{}"'.format(value))
+            raise ValidationError('FANTOIR must be municipality INSEE + 4 '
+                                  'first chars of FANTOIR, '
+                                  'got "{}" instead'.format(value))
         return value
 
 

--- a/ban/tests/test_validators.py
+++ b/ban/tests/test_validators.py
@@ -174,21 +174,21 @@ def test_cannot_create_postcode_with_code_shorter_than_5_chars(session):
     municipality = MunicipalityFactory(insee='12345')
     validator = models.PostCode.validator(code="3131", name="Montbrun-Bocage",
                                           municipality=municipality)
-    assert 'code' in validator.errors
+    assert validator.errors['code'] == 'Invalid postcode: "3131"'
 
 
 def test_cannot_create_postcode_with_code_bigger_than_5_chars(session):
     municipality = MunicipalityFactory(insee='12345')
     validator = models.PostCode.validator(code="313100", name="Montbrun",
                                           municipality=municipality)
-    assert 'code' in validator.errors
+    assert validator.errors['code'] == 'Invalid postcode: "313100"'
 
 
 def test_cannot_create_postcode_with_code_non_digit(session):
     municipality = MunicipalityFactory(insee='12345')
     validator = models.PostCode.validator(code="2A000", name="Montbrun-Bocage",
                                           municipality=municipality)
-    assert 'code' in validator.errors
+    assert validator.errors['code'] == 'Invalid postcode: "2A000"'
 
 
 def test_can_create_street(session):
@@ -247,7 +247,9 @@ def test_cannot_create_group_with_fantoir_greater_than_9or10_digits(session):
                                        kind=models.Group.WAY,
                                        municipality=municipality,
                                        fantoir='123456789012')
-    assert 'fantoir' in validator.errors
+    assert validator.errors['fantoir'] == ('FANTOIR must be municipality INSEE'
+                                           ' + 4 first chars of FANTOIR, got '
+                                           '"123456789012" instead')
 
 
 def test_can_create_street_with_municipality_insee(session):


### PR DESCRIPTION
We want "Invalid postcode: xxx" instead of "Unable to coerce value for postcode: xxxx".