### PR TITLE
Standardize error response format

### DIFF
--- a/ban/http/api.py
+++ b/ban/http/api.py
@@ -67,7 +67,7 @@ class ModelEndpoint(CollectionEndpoint):
         try:
             instance = self.model.coerce(identifier)
         except self.model.DoesNotExist:
-            abort(404, error='Resource for `{}` does not exist.'
+            abort(404, error='Resource with identifier `{}` does not exist.'
                   .format(identifier))
         except RedirectError as e:
             headers = {'Location': url_for(endpoint, identifier=e.redirect)}
@@ -86,7 +86,7 @@ class ModelEndpoint(CollectionEndpoint):
         validator = self.model.validator(update=update, instance=instance,
                                          **request.json or {})
         if validator.errors:
-            abort(422, errors=validator.errors)
+            abort(422, error='Invalid data', errors=validator.errors)
         try:
             instance = validator.save()
         except models.Model.ForcedVersionError as e:
@@ -350,7 +350,7 @@ class VersionedModelEnpoint(ModelEndpoint):
         instance = self.get_object(identifier)
         version = instance.load_version(ref)
         if not version:
-            abort(404)
+            abort(404, error='Version reference `{}` not found'.format(ref))
         return version.serialize()
 
     @auth.require_oauth()
@@ -373,7 +373,7 @@ class VersionedModelEnpoint(ModelEndpoint):
         instance = self.get_object(identifier)
         version = instance.load_version(ref)
         if not version:
-            abort(404)
+            abort(404, error='Version reference `{}` not found'.format(ref))
         status = request.json.get('status')
         if status is True:
             version.flag()

--- a/ban/http/wsgi.py
+++ b/ban/http/wsgi.py
@@ -8,6 +8,7 @@ from flask_cors import CORS
 from werkzeug.routing import BaseConverter, ValidationError
 
 from .schema import Schema
+from .utils import abort
 from ban.core.encoder import dumps
 
 
@@ -76,3 +77,15 @@ class DateTimeConverter(BaseConverter):
 app = application = App(__name__)
 CORS(app)
 app.url_map.converters['datetime'] = DateTimeConverter
+
+
+@app.errorhandler(404)
+@app.jsonify
+def page_not_found(error):
+    return {'error': 'Path not found'}, 404
+
+
+@app.errorhandler(405)
+@app.jsonify
+def method_not_allowed(error):
+    return {'error': 'Method not allowed'}, 405

--- a/ban/tests/http/test_flag.py
+++ b/ban/tests/http/test_flag.py
@@ -49,6 +49,18 @@ def test_can_flag_past_version(client):
     assert not version.flags.select().count()
 
 
+@authorize
+def test_invalid_reference_returns_404(client):
+    group = GroupFactory()
+    group.name = 'Another name'
+    group.increment_version()
+    group.save()
+    uri = '/group/{}/versions/9/flag'.format(group.id)
+    resp = client.post(uri, data={'status': True})
+    assert resp.status_code == 404
+    assert resp.json['error'] == 'Version reference `9` not found'
+
+
 def test_cannot_flag_without_token(client):
     group = GroupFactory()
     uri = '/group/{}/versions/1/flag'.format(group.id)

--- a/ban/tests/http/test_housenumber.py
+++ b/ban/tests/http/test_housenumber.py
@@ -343,6 +343,7 @@ def test_replace_housenumber_with_missing_field_fails(client):
     }
     resp = client.put(uri, data=data)
     assert resp.status_code == 422
+    assert resp.json['error'] == 'Invalid data'
     assert 'errors' in resp.json
     assert models.HouseNumber.select().count() == 1
 

--- a/ban/tests/http/test_http.py
+++ b/ban/tests/http/test_http.py
@@ -8,6 +8,19 @@ def test_cors_headers(get):
     assert resp.headers['Access-Control-Allow-Origin'] == '*'
 
 
+def test_invalid_route(get):
+    municipality = MunicipalityFactory()
+    resp = get('/municipalities/{}'.format(municipality.id))
+    assert resp.status_code == 404
+    assert resp.json['error'] == 'Path not found'
+
+
+def test_method_not_allowed(client):
+    resp = client.patch('/municipality/')
+    assert resp.status_code == 405
+    assert resp.json['error'] == 'Method not allowed'
+
+
 def test_link_headers():
     headers = {}
     link(headers, 'http://ban.fr', 'alternate')


### PR DESCRIPTION
Now every error will have a json body that contain at least
an `error` key, and optional other keys.

See #147 for rationale.
