### PR TITLE
[WIP] Implement soft delete (fix #81)

### DIFF
--- a/ban/commands/export.py
+++ b/ban/commands/export.py
@@ -16,6 +16,6 @@ def resources(path, **kwargs):
                  models.HouseNumber]
     with Path(path).open(mode='w', encoding='utf-8') as f:
         for resource in resources:
-            for data in resource.active().serialize({'*': {}}):
+            for data in resource.select().serialize({'*': {}}):
                 f.write(dumps(data) + '\n')
                 reporter.notice(resource.__name__, data)

--- a/ban/commands/export.py
+++ b/ban/commands/export.py
@@ -16,6 +16,6 @@ def resources(path, **kwargs):
                  models.HouseNumber]
     with Path(path).open(mode='w', encoding='utf-8') as f:
         for resource in resources:
-            for data in resource.select().serialize({'*': {}}):
+            for data in resource.active().serialize({'*': {}}):
                 f.write(dumps(data) + '\n')
                 reporter.notice(resource.__name__, data)

--- a/ban/core/exceptions.py
+++ b/ban/core/exceptions.py
@@ -2,6 +2,10 @@ class ValidationError(ValueError):
     ...
 
 
+class ResourceLinkedError(ValidationError):
+    ...
+
+
 class IsDeletedError(ValidationError):
 
     def __init__(self, instance):

--- a/ban/core/exceptions.py
+++ b/ban/core/exceptions.py
@@ -2,6 +2,16 @@ class ValidationError(ValueError):
     ...
 
 
+class IsDeletedError(ValidationError):
+
+    def __init__(self, instance):
+        self.instance = instance
+
+    def __str__(self):
+        msg = 'Resource `{}` with id `{}` is deleted'
+        return msg.format(self.instance.resource, self.instance.id)
+
+
 class RedirectError(ValueError):
 
     def __init__(self, identifier, value, redirect):

--- a/ban/core/models.py
+++ b/ban/core/models.py
@@ -4,7 +4,7 @@ import peewee
 from unidecode import unidecode
 
 from ban import db
-from ban.utils import compute_cia
+from ban.utils import compute_cia, utcnow
 from .versioning import Versioned, BaseVersioned
 from .resource import ResourceModel, BaseResource
 from .validators import VersionedResourceValidator

--- a/ban/core/resource.py
+++ b/ban/core/resource.py
@@ -134,8 +134,12 @@ class ResourceModel(db.Model, metaclass=BaseResource):
         return 'deleted' if self.deleted_at else 'active'
 
     @classmethod
-    def active(cls):
-        return cls.select().where(cls.deleted_at.is_null())
+    def select(cls, *selection):
+        return super().select(*selection).where(cls.deleted_at.is_null())
+
+    @classmethod
+    def raw_select(cls, *selection):
+        return super().select(*selection)
 
     def mark_deleted(self):
         if self.deleted_at:
@@ -168,7 +172,8 @@ class ResourceModel(db.Model, metaclass=BaseResource):
                 elif isinstance(id, int):
                     identifier = 'pk'
             try:
-                instance = cls.get(getattr(cls, identifier) == id)
+                instance = cls.raw_select().where(
+                    getattr(cls, identifier) == id).get()
             except cls.DoesNotExist:
                 # Is it an old identifier?
                 from .versioning import Redirect

--- a/ban/core/resource.py
+++ b/ban/core/resource.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 import uuid
+from datetime import datetime
 
 import peewee
 from postgis import Point
@@ -7,8 +7,9 @@ from postgis import Point
 from ban import db
 from ban.utils import utcnow
 
+from .exceptions import (IsDeletedError, MultipleRedirectsError, RedirectError,
+                         ResourceLinkedError)
 from .validators import ResourceValidator
-from .exceptions import RedirectError, MultipleRedirectsError, IsDeletedError
 
 
 class BaseResource(peewee.BaseModel):
@@ -147,7 +148,8 @@ class ResourceModel(db.Model, metaclass=BaseResource):
     def ensure_no_reverse_relation(self):
         for name, field in self._meta.reverse_rel.items():
             if getattr(self, name).count():
-                raise ValueError('Resource still linked by `{}`'.format(name))
+                raise ResourceLinkedError(
+                    'Resource still linked by `{}`'.format(name))
 
     @classmethod
     def coerce(cls, id, identifier=None):

--- a/ban/core/versioning.py
+++ b/ban/core/versioning.py
@@ -328,9 +328,10 @@ class Redirect(db.Model):
 
     @classmethod
     def follow(cls, model_name, identifier, value):
-        rows = cls.select(cls.model_id).where(cls.model_name == model_name.lower(),
-                                        cls.identifier == identifier,
-                                        cls.value == str(value))
+        rows = cls.select(cls.model_id).where(
+            cls.model_name == model_name.lower(),
+            cls.identifier == identifier,
+            cls.value == str(value))
         return [row.model_id for row in rows]
 
     @classmethod

--- a/ban/db/fields.py
+++ b/ban/db/fields.py
@@ -112,13 +112,13 @@ class ForeignKeyField(peewee.ForeignKeyField):
     def coerce(self, value):
         if not value:
             return None
-        if isinstance(value, peewee.Model):
-            value = value.pk
-        elif isinstance(value, dict):
+        if isinstance(value, dict):
             # We have a resource dict.
             value = value['id']
-        if isinstance(value, str) and hasattr(self.rel_model, 'coerce'):
-            value = self.rel_model.coerce(value).pk
+        if hasattr(self.rel_model, 'coerce'):
+            value = self.rel_model.coerce(value)
+        if isinstance(value, peewee.Model):
+            value = value.pk
         return super().coerce(value)
 
     def _get_related_name(self):
@@ -256,11 +256,7 @@ class ManyToManyField(fields.ManyToManyField):
             return []
         if not isinstance(value, (tuple, list, peewee.SelectQuery)):
             value = [value]
-        # https://github.com/coleifer/peewee/pull/795
-        value = [self.rel_model.coerce(item)
-                 if not isinstance(item, self.rel_model)
-                 else item
-                 for item in value]
+        value = [self.rel_model.coerce(item) for item in value]
         return super().coerce(value)
 
     def add_to_class(self, model_class, name):

--- a/ban/http/api.py
+++ b/ban/http/api.py
@@ -9,7 +9,7 @@ from ban.commands.bal import bal
 from ban.core import context, models, versioning
 from ban.core.encoder import dumps
 from ban.core.exceptions import (IsDeletedError, MultipleRedirectsError,
-                                 RedirectError)
+                                 RedirectError, ResourceLinkedError)
 from ban.http.auth import auth
 from ban.http.wsgi import app
 from ban.utils import parse_mask
@@ -336,9 +336,8 @@ class ModelEndpoint(CollectionEndpoint):
         instance = self.get_object(identifier)
         try:
             instance.mark_deleted()
-        except ValueError:
-            # This model was still pointed by a FK.
-            abort(409, error='Cannot delete this resource')
+        except ResourceLinkedError as e:
+            abort(409, error=str(e))
         return {'resource_id': identifier}
 
 

--- a/ban/http/api.py
+++ b/ban/http/api.py
@@ -99,7 +99,7 @@ class ModelEndpoint(CollectionEndpoint):
         return instance
 
     def get_queryset(self):
-        qs = self.model.active()
+        qs = self.model.select()
         for key in self.filters:
             values = request.args.getlist(key)
             if values:

--- a/ban/http/api.py
+++ b/ban/http/api.py
@@ -6,12 +6,13 @@ from flask import request, url_for
 
 from ban.auth import models as amodels
 from ban.commands.bal import bal
-from ban.core import models, versioning, context
+from ban.core import context, models, versioning
 from ban.core.encoder import dumps
-from ban.core.exceptions import RedirectError, MultipleRedirectsError
-from ban.utils import parse_mask
+from ban.core.exceptions import (IsDeletedError, MultipleRedirectsError,
+                                 RedirectError)
 from ban.http.auth import auth
 from ban.http.wsgi import app
+from ban.utils import parse_mask
 
 from .utils import abort, get_bbox, link
 
@@ -80,6 +81,10 @@ class ModelEndpoint(CollectionEndpoint):
                 link(headers, uri, 'alternate')
                 choices.append(uri)
             abort(300, headers=headers, choices=choices)
+        except IsDeletedError as err:
+            if request.method not in ['GET', 'PUT']:
+                abort(410, error='Resource `{}` is deleted'.format(identifier))
+            instance = err.instance
         return instance
 
     def save_object(self, instance=None, update=False):
@@ -94,7 +99,7 @@ class ModelEndpoint(CollectionEndpoint):
         return instance
 
     def get_queryset(self):
-        qs = self.model.select()
+        qs = self.model.active()
         for key in self.filters:
             values = request.args.getlist(key)
             if values:
@@ -170,10 +175,15 @@ class ModelEndpoint(CollectionEndpoint):
                 description: Get {resource} instance.
                 schema:
                     $ref: '#/definitions/{resource}'
+            410:
+                description: Resource is deleted.
+                schema:
+                    $ref: '#/definitions/{resource}'
         """
         instance = self.get_object(identifier)
+        status = 410 if instance.deleted_at else 200
         try:
-            return instance.serialize(self.get_mask())
+            return instance.serialize(self.get_mask()), status
         except ValueError as e:
             abort(400, error=str(e))
 
@@ -190,10 +200,14 @@ class ModelEndpoint(CollectionEndpoint):
                 description: Instance has been updated successfully.
                 schema:
                     $ref: '#/definitions/{resource}'
-            419:
+            409:
                 description: Conflict.
                 schema:
                     $ref: '#/definitions/{resource}'
+            410:
+                description: Resource is deleted.
+                schema:
+                    $ref: '#/definitions/Error'
             422:
                 description: Invalid data.
                 schema:
@@ -214,10 +228,14 @@ class ModelEndpoint(CollectionEndpoint):
                 description: Instance has been created successfully.
                 schema:
                     $ref: '#/definitions/{resource}'
-            419:
+            409:
                 description: Conflict.
                 schema:
                     $ref: '#/definitions/{resource}'
+            410:
+                description: Resource is deleted.
+                schema:
+                    $ref: '#/definitions/Error'
             422:
                 description: Invalid data.
                 schema:
@@ -241,10 +259,14 @@ class ModelEndpoint(CollectionEndpoint):
                 description: Instance has been updated successfully.
                 schema:
                     $ref: '#/definitions/{resource}'
-            419:
+            409:
                 description: Conflict.
                 schema:
                     $ref: '#/definitions/{resource}'
+            410:
+                description: Resource is deleted.
+                schema:
+                    $ref: '#/definitions/Error'
             422:
                 description: Invalid data.
                 schema:
@@ -258,7 +280,7 @@ class ModelEndpoint(CollectionEndpoint):
     @app.jsonify
     @app.endpoint('/<identifier>', methods=['PUT'])
     def put(self, identifier):
-        """Replace {resource}.
+        """Replace or restore {resource}.
 
         parameters:
             - $ref: '#/parameters/identifier'
@@ -267,16 +289,25 @@ class ModelEndpoint(CollectionEndpoint):
                 description: Instance has been replaced successfully.
                 schema:
                     $ref: '#/definitions/{resource}'
-            419:
+            409:
                 description: Conflict.
                 schema:
                     $ref: '#/definitions/{resource}'
+            410:
+                description: Resource is deleted.
+                schema:
+                    $ref: '#/definitions/Error'
             422:
                 description: Invalid data.
                 schema:
                     $ref: '#/definitions/Error'
         """
         instance = self.get_object(identifier)
+        if instance.deleted_at:
+            # We want to create only one new version for a restore. Change the
+            # property here, but let the save_object do the actual save
+            # if the data is valid.
+            instance.deleted_at = None
         instance = self.save_object(instance)
         return instance.as_resource
 
@@ -293,15 +324,19 @@ class ModelEndpoint(CollectionEndpoint):
                 description: Instance has been deleted successfully.
                 schema:
                     $ref: '#/definitions/{resource}'
-            419:
+            409:
                 description: Conflict.
                 schema:
                     $ref: '#/definitions/{resource}'
+            410:
+                description: Resource is already deleted.
+                schema:
+                    $ref: '#/definitions/Error'
         """
         instance = self.get_object(identifier)
         try:
-            instance.delete_instance()
-        except peewee.IntegrityError:
+            instance.mark_deleted()
+        except ValueError:
             # This model was still pointed by a FK.
             abort(409, error='Cannot delete this resource')
         return {'resource_id': identifier}
@@ -478,7 +513,7 @@ class HouseNumber(VersionedModelEnpoint):
                 qs = (parent_qs | qs)
             # We evaluate the qs ourselves here, because it's a CompoundSelect
             # that does not know about our SelectQuery custom methods (like
-            # `as_resource_list`), and CompoundSelect is hardcoded in peewee
+            # `serialize`), and CompoundSelect is hardcoded in peewee
             # SelectQuery, and we'd need to copy-paste code to be able to use
             # a custom CompoundQuery class instead.
             mask = self.get_collection_mask()

--- a/ban/tests/commands/test_commands.py
+++ b/ban/tests/commands/test_commands.py
@@ -115,6 +115,8 @@ def test_export_resources():
     street = factories.GroupFactory(municipality=mun)
     hn = factories.HouseNumberFactory(parent=street)
     factories.PositionFactory(housenumber=hn)
+    deleted = factories.PositionFactory(housenumber=hn)
+    deleted.mark_deleted()
     path = Path(__file__).parent / 'data/export.sjson'
     resources(path)
 

--- a/ban/tests/http/test_group.py
+++ b/ban/tests/http/test_group.py
@@ -234,7 +234,8 @@ def test_delete_street(client):
     resp = client.delete('/group/{}'.format(street.id))
     assert resp.status_code == 200
     assert resp.json['resource_id'] == street.id
-    assert not models.Group.select().count()
+    assert not models.Group.active().count()
+    assert models.Group.first(models.Group.pk == street.pk).deleted_at
 
 
 def test_cannot_delete_group_if_not_authorized(client):

--- a/ban/tests/http/test_group.py
+++ b/ban/tests/http/test_group.py
@@ -234,8 +234,9 @@ def test_delete_street(client):
     resp = client.delete('/group/{}'.format(street.id))
     assert resp.status_code == 200
     assert resp.json['resource_id'] == street.id
-    assert not models.Group.active().count()
-    assert models.Group.first(models.Group.pk == street.pk).deleted_at
+    assert not models.Group.select().count()
+    assert models.Group.raw_select().where(
+                                models.Group.pk == street.pk).get().deleted_at
 
 
 def test_cannot_delete_group_if_not_authorized(client):

--- a/ban/tests/http/test_housenumber.py
+++ b/ban/tests/http/test_housenumber.py
@@ -386,9 +386,9 @@ def test_delete_housenumber(client):
     resp = client.delete(uri)
     assert resp.status_code == 200
     assert resp.json['resource_id'] == housenumber.id
-    assert not models.HouseNumber.active().count()
-    assert models.HouseNumber.first(
-                        models.HouseNumber.pk == housenumber.pk).deleted_at
+    assert not models.HouseNumber.select().count()
+    assert models.HouseNumber.raw_select().where(
+                    models.HouseNumber.pk == housenumber.pk).get().deleted_at
 
 
 def test_cannot_delete_housenumber_if_not_authorized(client):

--- a/ban/tests/http/test_housenumber.py
+++ b/ban/tests/http/test_housenumber.py
@@ -34,7 +34,8 @@ def test_get_housenumber(get):
         'laposte': None,
         'ordinal': 'bis',
         'positions': [],
-        'postcode': None
+        'postcode': None,
+        'status': 'active',
     }
 
 
@@ -385,7 +386,9 @@ def test_delete_housenumber(client):
     resp = client.delete(uri)
     assert resp.status_code == 200
     assert resp.json['resource_id'] == housenumber.id
-    assert not models.HouseNumber.select().count()
+    assert not models.HouseNumber.active().count()
+    assert models.HouseNumber.first(
+                        models.HouseNumber.pk == housenumber.pk).deleted_at
 
 
 def test_cannot_delete_housenumber_if_not_authorized(client):

--- a/ban/tests/http/test_municipality.py
+++ b/ban/tests/http/test_municipality.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from ban.core import models
 from ban.core.encoder import dumps
 from ban.core.versioning import Version, Redirect
+from ban.utils import utcnow
 
 from ..factories import MunicipalityFactory, PostCodeFactory, GroupFactory
 from .utils import authorize
@@ -264,7 +265,9 @@ def test_delete_municipality(client):
     resp = client.delete('/municipality/{}'.format(municipality.id))
     assert resp.status_code == 200
     assert resp.json['resource_id'] == municipality.id
-    assert not models.Municipality.select().count()
+    assert not models.Municipality.active().count()
+    assert models.Municipality.first(
+                        models.Municipality.pk == municipality.pk).deleted_at
 
 
 def test_cannot_delete_municipality_if_not_authorized(client):
@@ -290,6 +293,94 @@ def test_delete_unknown_municipality_should_return_not_found(client):
 
 
 @authorize
+def test_can_get_deleted_municipality(get):
+    municipality = MunicipalityFactory()
+    municipality.mark_deleted()
+    resp = get('/municipality/{}'.format(municipality.id))
+    assert resp.status_code == 410
+    assert resp.json['id'] == municipality.id
+    assert len(municipality.versions) == 2
+
+
+@authorize
+def test_can_get_deleted_municipality_versions(get):
+    municipality = MunicipalityFactory(name="Cabour")
+    municipality.version = 2
+    municipality.name = "Cabour2"
+    municipality.save()
+    resp = get('/municipality/{}/versions'.format(municipality.id))
+    assert resp.status_code == 200
+    assert len(resp.json['collection']) == 2
+    assert resp.json['total'] == 2
+    assert resp.json['collection'][0]['data']['name'] == 'Cabour'
+    assert resp.json['collection'][1]['data']['name'] == 'Cabour2'
+
+
+@authorize
+def test_can_get_deleted_municipality_version(get):
+    municipality = MunicipalityFactory(name="Cabour")
+    municipality.version = 2
+    municipality.name = "Cabour2"
+    municipality.save()
+    resp = get('/municipality/{}/versions/2'.format(municipality.id))
+    assert resp.status_code == 200
+    assert resp.json['data']['name'] == 'Cabour2'
+
+
+@authorize
+def test_cannot_post_on_deleted_municipality(post):
+    municipality = MunicipalityFactory()
+    municipality.mark_deleted()
+    resp = post('/municipality/{}'.format(municipality.id), data={})
+    assert resp.status_code == 410
+
+
+@authorize
+def test_cannot_patch_on_deleted_municipality(patch):
+    municipality = MunicipalityFactory()
+    municipality.mark_deleted()
+    resp = patch('/municipality/{}'.format(municipality.id), data={})
+    assert resp.status_code == 410
+
+
+@authorize
+def test_can_restore_municipality(client):
+    municipality = MunicipalityFactory()
+    municipality.mark_deleted()
+    data = municipality.serialize({'*': {}})
+    data['version'] = 3
+    resp = client.put('/municipality/{}'.format(municipality.id), data=data)
+    assert resp.status_code == 200
+    assert not models.Municipality.get(
+        models.Municipality.pk == municipality.pk).deleted_at
+    assert len(municipality.versions) == 3
+
+
+@authorize
+def test_cannot_restore_municipality_without_changing_version(client):
+    municipality = MunicipalityFactory()
+    municipality.mark_deleted()
+    data = municipality.serialize({'*': {}})
+    resp = client.put('/municipality/{}'.format(municipality.id), data=data)
+    assert resp.status_code == 409
+    assert models.Municipality.get(
+        models.Municipality.pk == municipality.pk).deleted_at
+
+
+@authorize
+def test_cannot_restore_municipality_with_invalid_data(client):
+    municipality = MunicipalityFactory()
+    municipality.mark_deleted()
+    data = municipality.serialize({'*': {}})
+    data['name'] = ''
+    data['version'] = 3
+    resp = client.put('/municipality/{}'.format(municipality.id), data=data)
+    assert resp.status_code == 422
+    assert models.Municipality.get(
+        models.Municipality.pk == municipality.pk).deleted_at
+
+
+@authorize
 def test_municipality_select_use_default_orderby(get):
     MunicipalityFactory(insee="90002")
     MunicipalityFactory(insee="90001")
@@ -297,3 +388,49 @@ def test_municipality_select_use_default_orderby(get):
     assert resp.status_code == 200
     assert resp.json['total'] == 2
     assert resp.json['collection'][0]['insee'] == '90001'
+
+
+@authorize
+def test_status_is_readonly(post):
+    municipality = MunicipalityFactory()
+    data = municipality.serialize({'*': {}})
+    data['status'] = 'deleted'
+    data['version'] = 2
+    resp = post('/municipality/{}'.format(municipality.id), data=data)
+    assert resp.status_code == 200
+
+
+@authorize
+def test_cannot_change_deleted_at_with_post(post):
+    municipality = MunicipalityFactory()
+    data = municipality.serialize({'*': {}})
+    data['deleted_at'] = utcnow().isoformat()
+    data['version'] = 2
+    resp = post('/municipality/{}'.format(municipality.id), data=data)
+    assert resp.status_code == 200
+    assert not models.Municipality.get(
+        models.Municipality.pk == municipality.pk).deleted_at
+
+
+@authorize
+def test_cannot_change_deleted_at_with_patch(patch):
+    municipality = MunicipalityFactory()
+    data = municipality.serialize({'*': {}})
+    data['deleted_at'] = utcnow().isoformat()
+    data['version'] = 2
+    resp = patch('/municipality/{}'.format(municipality.id), data=data)
+    assert resp.status_code == 200
+    assert not models.Municipality.get(
+        models.Municipality.pk == municipality.pk).deleted_at
+
+
+@authorize
+def test_cannot_change_deleted_at_with_put(put):
+    municipality = MunicipalityFactory()
+    data = municipality.serialize({'*': {}})
+    data['deleted_at'] = utcnow().isoformat()
+    data['version'] = 2
+    resp = put('/municipality/{}'.format(municipality.id), data=data)
+    assert resp.status_code == 200
+    assert not models.Municipality.get(
+        models.Municipality.pk == municipality.pk).deleted_at

--- a/ban/tests/http/test_municipality.py
+++ b/ban/tests/http/test_municipality.py
@@ -265,9 +265,9 @@ def test_delete_municipality(client):
     resp = client.delete('/municipality/{}'.format(municipality.id))
     assert resp.status_code == 200
     assert resp.json['resource_id'] == municipality.id
-    assert not models.Municipality.active().count()
-    assert models.Municipality.first(
-                        models.Municipality.pk == municipality.pk).deleted_at
+    assert not models.Municipality.select().count()
+    assert models.Municipality.raw_select().where(
+                models.Municipality.pk == municipality.pk).first().deleted_at
 
 
 def test_cannot_delete_municipality_if_not_authorized(client):
@@ -364,8 +364,8 @@ def test_cannot_restore_municipality_without_changing_version(client):
     data = municipality.serialize({'*': {}})
     resp = client.put('/municipality/{}'.format(municipality.id), data=data)
     assert resp.status_code == 409
-    assert models.Municipality.get(
-        models.Municipality.pk == municipality.pk).deleted_at
+    assert models.Municipality.raw_select().where(
+        models.Municipality.pk == municipality.pk).get().deleted_at
 
 
 @authorize
@@ -377,8 +377,8 @@ def test_cannot_restore_municipality_with_invalid_data(client):
     data['version'] = 3
     resp = client.put('/municipality/{}'.format(municipality.id), data=data)
     assert resp.status_code == 422
-    assert models.Municipality.get(
-        models.Municipality.pk == municipality.pk).deleted_at
+    assert models.Municipality.raw_select().where(
+        models.Municipality.pk == municipality.pk).get().deleted_at
 
 
 @authorize

--- a/ban/tests/http/test_municipality.py
+++ b/ban/tests/http/test_municipality.py
@@ -283,6 +283,7 @@ def test_cannot_delete_municipality_if_linked_to_street(client):
     GroupFactory(municipality=municipality)
     resp = client.delete('/municipality/{}'.format(municipality.id))
     assert resp.status_code == 409
+    assert resp.json['error'] == 'Resource still linked by `groups`'
     assert models.Municipality.get(models.Municipality.id == municipality.id)
 
 

--- a/ban/tests/http/test_position.py
+++ b/ban/tests/http/test_position.py
@@ -352,9 +352,9 @@ def test_delete_position(client, url):
     resp = client.delete(uri)
     assert resp.status_code == 200
     assert resp.json['resource_id'] == position.id
-    assert not models.Position.active().count()
-    assert models.Position.first(
-                        models.Position.pk == position.pk).deleted_at
+    assert not models.Position.select().count()
+    assert models.Position.raw_select().where(
+                        models.Position.pk == position.pk).get().deleted_at
 
 
 def test_cannot_delete_position_if_not_authorized(client, url):

--- a/ban/tests/http/test_position.py
+++ b/ban/tests/http/test_position.py
@@ -352,7 +352,9 @@ def test_delete_position(client, url):
     resp = client.delete(uri)
     assert resp.status_code == 200
     assert resp.json['resource_id'] == position.id
-    assert not models.Position.select().count()
+    assert not models.Position.active().count()
+    assert models.Position.first(
+                        models.Position.pk == position.pk).deleted_at
 
 
 def test_cannot_delete_position_if_not_authorized(client, url):

--- a/ban/tests/test_diff.py
+++ b/ban/tests/test_diff.py
@@ -34,3 +34,12 @@ def test_adding_value_to_arrayfield_column():
     assert len(diff.diff) == 1  # name, siren
     assert diff.diff['alias']['old'] is None
     assert diff.diff['alias']['new'] == ['Orvanne']
+
+
+def test_delete_should_create_a_diff():
+    municipality = MunicipalityFactory()
+    municipality.mark_deleted()
+    diff = municipality.versions[1].diff
+    assert len(diff.diff) == 1  # name, siren
+    assert diff.diff['status']['old'] == 'active'
+    assert diff.diff['status']['new'] == 'deleted'

--- a/ban/tests/test_models.py
+++ b/ban/tests/test_models.py
@@ -155,7 +155,7 @@ def test_group_as_relation():
         'attributes': None,
         'laposte': None,
         'addressing': None,
-        'version': 1
+        'version': 1,
     }
 
 
@@ -325,6 +325,7 @@ def test_housenumber_as_resource():
         'created_at': housenumber.created_at.isoformat(),
         'modified_by': housenumber.modified_by.serialize(),
         'modified_at': housenumber.modified_at.isoformat(),
+        'status': 'active',
     }
 
 

--- a/ban/tests/test_serialize.py
+++ b/ban/tests/test_serialize.py
@@ -44,6 +44,7 @@ def test_serialize_with_wildcard():
         'laposte': None,
         'addressing': None,
         'version': 1,
+        'status': 'active',
         'modified_at': group.modified_at.isoformat(),
         'created_at': group.created_at.isoformat(),
         'created_by': {
@@ -76,6 +77,7 @@ def test_serialize_with_wildcard_in_relation():
             'laposte': None,
             'addressing': None,
             'version': 1,
+            'status': 'active',
             'modified_at': group.modified_at.isoformat(),
             'created_at': group.created_at.isoformat(),
             'created_by': {
@@ -120,6 +122,7 @@ def test_serialize_with_double_wildcard():
         'ign': None,
         'attributes': None,
         'positions': [],
+        'status': 'active',
         'parent': {
             'name': 'Rue de la Banatouille',
             'id': group.id,
@@ -133,6 +136,7 @@ def test_serialize_with_double_wildcard():
             'laposte': None,
             'addressing': None,
             'version': 1,
+            'status': 'active',
             'modified_at': group.modified_at.isoformat(),
             'created_at': group.created_at.isoformat(),
             'created_by': {

--- a/ban/tests/test_version.py
+++ b/ban/tests/test_version.py
@@ -24,7 +24,9 @@ def test_municipality_version():
         'alias': ['Rijsel'],
         'created_by': municipality.created_by.serialize(),
         'modified_at': municipality.modified_at.isoformat(),
-        'version': 1}
+        'version': 1,
+        'status': 'active',
+    }
 
 
 def test_municipality_is_versioned():
@@ -105,7 +107,9 @@ def test_group_version():
         'alias': ['Rue du Prince Louison'],
         'created_by': group.created_by.serialize(),
         'modified_at': group.modified_at.isoformat(),
-        'version': 1}
+        'version': 1,
+        'status': 'active',
+    }
 
 
 def test_housenumber_is_versioned():
@@ -147,7 +151,9 @@ def test_housenumber_as_version():
         'parent': street.id,
         'modified_by': hn.modified_by.serialize(),
         'positions': [],
-        'attributes': None}
+        'attributes': None,
+        'status': 'active',
+    }
 
 
 def test_position_is_versioned():
@@ -188,4 +194,6 @@ def test_position_as_version():
         'center': {'coordinates': (-1.1111, 48.8888), 'type': 'Point'},
         'comment': None,
         'laposte': None,
-        'id': position.id}
+        'id': position.id,
+        'status': 'active',
+    }


### PR DESCRIPTION
- [x] Define best property for `deleted` status: `deteled_at` or `status=online/deleted` or `deleted=True/False` or `online=True/False` or something else
- [x] Do not expose `status` in default relation serialization
- [x] Add unit tests to make sure we cannot create a relation pointing to a deleted object
- [x] Make sure we can access the versions of a deleted resource
- [x] Return 410 for GET on deleted resource (but serve the resource)
- [x] Manage resource restore
- [x] Make sure deleting a resource creates only one new version
- [x] Make sure restoring a resource creates only one new version
- [x] Make sure only active content is exported
- [x] Make sure we cannot set deleted_at with a normal PATCH, PUT or POST
