### PR TITLE
[WIP] Openapi > SwaggerUI compatibilty...

### DIFF
--- a/ban/core/encoder.py
+++ b/ban/core/encoder.py
@@ -15,5 +15,7 @@ class ResourceEncoder(json.JSONEncoder):
             return o.__json__()
 
 
-def dumps(data):
-    return json.dumps(data, cls=ResourceEncoder)
+def dumps(data, **kwargs):
+    kwargs.setdefault('cls', ResourceEncoder)
+    # return json.dumps(data, cls=ResourceEncoder)
+    return json.dumps(data, **kwargs)

--- a/ban/core/models.py
+++ b/ban/core/models.py
@@ -160,6 +160,7 @@ class Position(Model):
     SEGMENT = 'segment'
     UTILITY = 'utility'
     UNKNOWN = 'unknown'
+    AREA = 'area'
     KIND = (
         (POSTAL, _('postal delivery')),
         (ENTRANCE, _('entrance')),
@@ -169,6 +170,7 @@ class Position(Model):
         (PARCEL, _('parcel')),
         (SEGMENT, _('road segment')),
         (UTILITY, _('utility service')),
+        (AREA, _('area')),
         (UNKNOWN, _('unknown')),
     )
 

--- a/ban/core/versioning.py
+++ b/ban/core/versioning.py
@@ -272,6 +272,13 @@ class Diff(db.Model):
 
 class Redirect(db.Model):
 
+    __openapi__ = """
+        properties:
+            identifier_value:
+                type: string
+                description: Identifier name ':' Value for identifier
+        """
+
     model_name = db.CharField(max_length=64)
     model_id = db.CharField(max_length=255)
     identifier = db.CharField(max_length=64)
@@ -328,9 +335,11 @@ class Redirect(db.Model):
 
     @classmethod
     def follow(cls, model_name, identifier, value):
-        rows = cls.select(cls.model_id).where(cls.model_name == model_name.lower(),
-                                        cls.identifier == identifier,
-                                        cls.value == str(value))
+        rows = cls.select(cls.model_id).where(
+            cls.model_name == model_name.lower(),
+            cls.identifier == identifier,
+            cls.value == str(value)
+        )
         return [row.model_id for row in rows]
 
     @classmethod

--- a/ban/http/api.py
+++ b/ban/http/api.py
@@ -129,6 +129,8 @@ class ModelEndpoint(CollectionEndpoint):
     def get_collection(self):
         """Get {resource} collection.
 
+        tags: [{resource}]
+
         responses:
             200:
                 description: Get {resource} collection.
@@ -163,6 +165,8 @@ class ModelEndpoint(CollectionEndpoint):
     def get_resource(self, identifier):
         """Get {resource} with 'identifier'.
 
+        tags: [{resource}]
+
         parameters:
             - $ref: '#/parameters/identifier'
         responses:
@@ -182,6 +186,8 @@ class ModelEndpoint(CollectionEndpoint):
     @app.endpoint('/<identifier>', methods=['POST'])
     def post_resource(self, identifier):
         """Patch {resource} with 'identifier'.
+
+        tags: [{resource}]
 
         parameters:
             - $ref: '#/parameters/identifier'
@@ -209,6 +215,8 @@ class ModelEndpoint(CollectionEndpoint):
     def post(self):
         """Create {resource}
 
+        tags: [{resource}]
+
         responses:
             201:
                 description: Instance has been created successfully.
@@ -233,6 +241,8 @@ class ModelEndpoint(CollectionEndpoint):
     @app.endpoint('/<identifier>', methods=['PATCH'])
     def patch(self, identifier):
         """Patch {resource}
+
+        tags: [{resource}]
 
         parameters:
             - $ref: '#/parameters/identifier'
@@ -260,6 +270,8 @@ class ModelEndpoint(CollectionEndpoint):
     def put(self, identifier):
         """Replace {resource}.
 
+        tags: [{resource}]
+
         parameters:
             - $ref: '#/parameters/identifier'
         responses:
@@ -285,6 +297,8 @@ class ModelEndpoint(CollectionEndpoint):
     @app.endpoint('/<identifier>', methods=['DELETE'])
     def delete(self, identifier):
         """Delete {resource}.
+
+        tags: [{resource}]
 
         parameters:
             - $ref: '#/parameters/identifier'
@@ -314,6 +328,8 @@ class VersionedModelEnpoint(ModelEndpoint):
     def get_versions(self, identifier):
         """Get resource versions.
 
+        tags: [{resource}]
+
         parameters:
             - $ref: '#/parameters/identifier'
         responses:
@@ -333,6 +349,8 @@ class VersionedModelEnpoint(ModelEndpoint):
     @app.endpoint('/<identifier>/versions/<int:ref>', methods=['GET'])
     def get_version(self, identifier, ref):
         """Get {resource} version corresponding to 'ref' number or datetime.
+
+        tags: [{resource}]
 
         parameters:
             - $ref: '#/parameters/identifier'
@@ -358,6 +376,8 @@ class VersionedModelEnpoint(ModelEndpoint):
     @app.endpoint('/<identifier>/versions/<int:ref>/flag', methods=['POST'])
     def post_version(self, identifier, ref):
         """Flag a version.
+
+        tags: [{resource}]
 
         parameters:
             - $ref: '#/parameters/identifier'
@@ -386,6 +406,8 @@ class VersionedModelEnpoint(ModelEndpoint):
     @app.endpoint('/<identifier>/redirects/<old>', methods=['PUT', 'DELETE'])
     def put_delete_redirects(self, identifier, old):
         """Create a new redirect to this resource.
+
+        tags: [{resource}]
 
         parameters:
             - $ref: '#/parameters/identifier'
@@ -419,6 +441,8 @@ class VersionedModelEnpoint(ModelEndpoint):
     @app.endpoint('/<identifier>/redirects', methods=['GET'])
     def get_redirects(self, identifier):
         """Get a collection of Redirect pointing to this resource.
+
+        tags: [{resource}]
 
         parameters:
             - $ref: '#/parameters/identifier'
@@ -538,6 +562,8 @@ class DiffEndpoint(CollectionEndpoint):
     @app.endpoint('', methods=['GET'])
     def get_collection(self):
         """Get database diffs.
+
+        tags: ['Diff']
 
         parameters:
         - name: increment

--- a/ban/http/api.py
+++ b/ban/http/api.py
@@ -147,7 +147,8 @@ class ModelEndpoint(CollectionEndpoint):
                         type: integer
                         description: total resources available
             401:
-                description: Unauthorized access.
+                $ref: '#/responses/401'
+
         """
         qs = self.get_queryset()
         if qs is None:
@@ -177,9 +178,9 @@ class ModelEndpoint(CollectionEndpoint):
                 schema:
                     $ref: '#/definitions/{resource}'
             401:
-                description: Unauthorized access.
+                $ref: '#/responses/401'
             404:
-                description: Resource does not exist.
+                $ref: '#/responses/404'
         """
         instance = self.get_object(identifier)
         try:
@@ -210,11 +211,11 @@ class ModelEndpoint(CollectionEndpoint):
                 schema:
                     $ref: '#/definitions/{resource}'
             400:
-                description: Bad Request.
+                $ref: '#/responses/400'
             401:
-                description: Unauthorized access.
+                $ref: '#/responses/401'
             404:
-                description: Resource does not exist.
+                $ref: '#/responses/404'
             419:
                 description: Conflict.
                 schema:
@@ -249,9 +250,9 @@ class ModelEndpoint(CollectionEndpoint):
                 schema:
                     $ref: '#/definitions/{resource}'
             400:
-                description: Bad Request.
+                $ref: '#/responses/400'
             401:
-                description: Unauthorized access.
+                $ref: '#/responses/401'
             419:
                 description: Conflict.
                 schema:
@@ -289,11 +290,11 @@ class ModelEndpoint(CollectionEndpoint):
                 schema:
                     $ref: '#/definitions/{resource}'
             400:
-                description: Bad Request.
+                $ref: '#/responses/400'
             401:
-                description: Unauthorized access.
+                $ref: '#/responses/401'
             404:
-                description: Resource does not exist.
+                $ref: '#/responses/404'
             419:
                 description: Conflict.
                 schema:
@@ -330,11 +331,11 @@ class ModelEndpoint(CollectionEndpoint):
                 schema:
                     $ref: '#/definitions/{resource}'
             400:
-                description: Bad Request.
+                $ref: '#/responses/400'
             401:
-                description: Unauthorized access.
+                $ref: '#/responses/401'
             404:
-                description: Resource does not exist.
+                $ref: '#/responses/404'
             419:
                 description: Conflict.
                 schema:
@@ -363,9 +364,9 @@ class ModelEndpoint(CollectionEndpoint):
                 schema:
                     $ref: '#/definitions/{resource}'
             401:
-                description: Unauthorized access.
+                $ref: '#/responses/401'
             404:
-                description: Resource does not exist.
+                $ref: '#/responses/404'
             419:
                 description: Conflict.
                 schema:
@@ -406,9 +407,9 @@ class VersionedModelEnpoint(ModelEndpoint):
                             type: integer
                             description: total resources available
             401:
-                description: Unauthorized access.
+                $ref: '#/responses/401'
             404:
-                description: Resource does not exist.
+                $ref: '#/responses/404'
         """
         instance = self.get_object(identifier)
         return self.collection(instance.versions.serialize())
@@ -435,11 +436,11 @@ class VersionedModelEnpoint(ModelEndpoint):
                 schema:
                     $ref: '#/definitions/Version'
             400:
-                description: Bad Request.
+                $ref: '#/responses/400'
             401:
-                description: Unauthorized access.
+                $ref: '#/responses/401'
             404:
-                description: Resource does not exist.
+                $ref: '#/responses/404'
         """
         instance = self.get_object(identifier)
         version = instance.load_version(ref)
@@ -472,9 +473,9 @@ class VersionedModelEnpoint(ModelEndpoint):
             200:
                 description: version flag was updated.
             400:
-                description: Bad Request.
+                $ref: '#/responses/400'
             401:
-                description: Unauthorized access.
+                $ref: '#/responses/401'
         """
         instance = self.get_object(identifier)
         version = instance.load_version(ref)
@@ -506,9 +507,9 @@ class VersionedModelEnpoint(ModelEndpoint):
             201:
                 description: redirect was successfully created.
             401:
-                description: Unauthorized access.
+                $ref: '#/responses/401'
             404:
-                description: Resource does not exist.
+                $ref: '#/responses/404'
             422:
                 description: error while creating the redirect.
         """
@@ -538,9 +539,9 @@ class VersionedModelEnpoint(ModelEndpoint):
             204:
                 description: redirect was successfully deleted.
             401:
-                description: Unauthorized access.
+                $ref: '#/responses/401'
             404:
-                description: Resource does not exist.
+                $ref: '#/responses/404'
             422:
                 description: error while deleting the redirect.
         """
@@ -563,9 +564,9 @@ class VersionedModelEnpoint(ModelEndpoint):
             200:
                 description: A list of redirects (identifier:value)
             401:
-                description: Unauthorized access.
+                $ref: '#/responses/401'
             404:
-                description: Resource does not exist.
+                $ref: '#/responses/404'
         """
         instance = self.get_object(identifier)
         cls = versioning.Redirect
@@ -705,7 +706,8 @@ class DiffEndpoint(CollectionEndpoint):
             400:
                 description: Invalid value for increment
             401:
-                description: Unauthorized access.
+                $ref: '#/responses/401'
+
          """
         qs = versioning.Diff.select()
         try:

--- a/ban/http/api.py
+++ b/ban/http/api.py
@@ -671,7 +671,7 @@ def bal_post():
 
 
 @app.resource
-class DiffEndpoint(CollectionEndpoint):
+class Diff(CollectionEndpoint):
     endpoint = '/diff'
     model = versioning.Diff
 

--- a/ban/http/api.py
+++ b/ban/http/api.py
@@ -131,7 +131,6 @@ class ModelEndpoint(CollectionEndpoint):
         """Get {resource} collection.
 
         tags: [{resource}]
-
         responses:
             200:
                 description: Get {resource} collection.
@@ -167,7 +166,6 @@ class ModelEndpoint(CollectionEndpoint):
         """Get {resource} with 'identifier'.
 
         tags: [{resource}]
-
         parameters:
             - $ref: '#/parameters/identifier'
         responses:
@@ -189,7 +187,6 @@ class ModelEndpoint(CollectionEndpoint):
         """Post {resource} with 'identifier'.
 
         tags: [{resource}]
-
         parameters:
             - $ref: '#/parameters/identifier'
         responses:
@@ -217,7 +214,6 @@ class ModelEndpoint(CollectionEndpoint):
         """Create a {resource}.
 
         tags: [{resource}]
-
         responses:
             201:
                 description: Instance has been created successfully.
@@ -244,7 +240,6 @@ class ModelEndpoint(CollectionEndpoint):
         """Patch {resource} with 'identifier'.
 
         tags: [{resource}]
-
         parameters:
             - $ref: '#/parameters/identifier'
         responses:
@@ -272,7 +267,6 @@ class ModelEndpoint(CollectionEndpoint):
         """Replace {resource} with 'identifier'.
 
         tags: [{resource}]
-
         parameters:
             - $ref: '#/parameters/identifier'
         responses:
@@ -300,7 +294,6 @@ class ModelEndpoint(CollectionEndpoint):
         """Delete {resource}.
 
         tags: [{resource}]
-
         parameters:
             - $ref: '#/parameters/identifier'
         responses:
@@ -330,7 +323,6 @@ class VersionedModelEnpoint(ModelEndpoint):
         """Get {resource} versions.
 
         tags: [{resource}]
-
         parameters:
             - $ref: '#/parameters/identifier'
         responses:
@@ -352,7 +344,6 @@ class VersionedModelEnpoint(ModelEndpoint):
         """Get {resource} version corresponding to 'ref' number or datetime.
 
         tags: [{resource}]
-
         parameters:
             - $ref: '#/parameters/identifier'
             - name: ref
@@ -379,7 +370,6 @@ class VersionedModelEnpoint(ModelEndpoint):
         """Flag a {resource} version.
 
         tags: [{resource}]
-
         parameters:
             - $ref: '#/parameters/identifier'
             - name: ref
@@ -409,7 +399,6 @@ class VersionedModelEnpoint(ModelEndpoint):
         """Create a new redirect to this {resource}.
 
         tags: [{resource}]
-
         parameters:
             - $ref: '#/parameters/identifier'
             - name: old
@@ -437,7 +426,6 @@ class VersionedModelEnpoint(ModelEndpoint):
         """Delete a redirect to this {resource}.
 
         tags: [{resource}]
-
         parameters:
             - $ref: '#/parameters/identifier'
             - name: old
@@ -463,7 +451,6 @@ class VersionedModelEnpoint(ModelEndpoint):
         """Get a collection of Redirect pointing to this {resource}.
 
         tags: [{resource}]
-
         parameters:
             - $ref: '#/parameters/identifier'
         responses:

--- a/ban/http/api.py
+++ b/ban/http/api.py
@@ -1,6 +1,7 @@
 from io import StringIO
 from urllib.parse import urlencode
 
+import json
 import peewee
 from flask import request, url_for
 
@@ -610,7 +611,7 @@ class DiffEndpoint(CollectionEndpoint):
 
 @app.route('/openapi', methods=['GET'])
 def openapi():
-    return dumps(app._schema)
+    return json.dumps(app._schema, sort_keys=True)
 
 
 app._schema.register_model(amodels.Session)

--- a/ban/http/api.py
+++ b/ban/http/api.py
@@ -146,6 +146,8 @@ class ModelEndpoint(CollectionEndpoint):
                         name: total
                         type: integer
                         description: total resources available
+            401:
+                description: Unauthorized access.
         """
         qs = self.get_queryset()
         if qs is None:
@@ -168,11 +170,16 @@ class ModelEndpoint(CollectionEndpoint):
         tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
         responses:
             200:
                 description: Get {resource} instance.
                 schema:
                     $ref: '#/definitions/{resource}'
+            401:
+                description: Unauthorized access.
+            404:
+                description: Resource does not exist.
         """
         instance = self.get_object(identifier)
         try:
@@ -189,11 +196,25 @@ class ModelEndpoint(CollectionEndpoint):
         tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
+            - name: body
+              in: body
+              schema:
+                $ref: '#/definitions/{resource}'
+              required: true
+              description:
+                {resource} object that needs to be updated to the BAN
         responses:
             200:
-                description: Instance has been updated successfully.
+                description: Instance has been successfully updated.
                 schema:
                     $ref: '#/definitions/{resource}'
+            400:
+                description: Bad Request.
+            401:
+                description: Unauthorized access.
+            404:
+                description: Resource does not exist.
             419:
                 description: Conflict.
                 schema:
@@ -214,11 +235,23 @@ class ModelEndpoint(CollectionEndpoint):
         """Create a {resource}.
 
         tags: [{resource}]
+        parameters:
+            - name: body
+              in: body
+              schema:
+                $ref: '#/definitions/{resource}'
+              required: true
+              description:
+                {resource} object that needs to be added to the BAN
         responses:
             201:
                 description: Instance has been created successfully.
                 schema:
                     $ref: '#/definitions/{resource}'
+            400:
+                description: Bad Request.
+            401:
+                description: Unauthorized access.
             419:
                 description: Conflict.
                 schema:
@@ -242,11 +275,25 @@ class ModelEndpoint(CollectionEndpoint):
         tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
+            - name: body
+              in: body
+              schema:
+                $ref: '#/definitions/{resource}'
+              required: true
+              description:
+                {resource} object that needs to be updated to the BAN
         responses:
             200:
                 description: Instance has been updated successfully.
                 schema:
                     $ref: '#/definitions/{resource}'
+            400:
+                description: Bad Request.
+            401:
+                description: Unauthorized access.
+            404:
+                description: Resource does not exist.
             419:
                 description: Conflict.
                 schema:
@@ -269,11 +316,25 @@ class ModelEndpoint(CollectionEndpoint):
         tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
+            - name: body
+              in: body
+              schema:
+                $ref: '#/definitions/{resource}'
+              required: true
+              description:
+                {resource} object that needs to be replaced to the BAN
         responses:
             200:
                 description: Instance has been replaced successfully.
                 schema:
                     $ref: '#/definitions/{resource}'
+            400:
+                description: Bad Request.
+            401:
+                description: Unauthorized access.
+            404:
+                description: Resource does not exist.
             419:
                 description: Conflict.
                 schema:
@@ -301,6 +362,10 @@ class ModelEndpoint(CollectionEndpoint):
                 description: Instance has been deleted successfully.
                 schema:
                     $ref: '#/definitions/{resource}'
+            401:
+                description: Unauthorized access.
+            404:
+                description: Resource does not exist.
             419:
                 description: Conflict.
                 schema:
@@ -325,13 +390,25 @@ class VersionedModelEnpoint(ModelEndpoint):
         tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
         responses:
             200:
                 description: Version collection for resource {resource}.
                 schema:
-                    type: array
-                    items:
-                        $ref: '#/definitions/Version'
+                    type: object
+                    properties:
+                        collection:
+                            type: array
+                            items:
+                                $ref: '#/definitions/Version'
+                        total:
+                            name: total
+                            type: integer
+                            description: total resources available
+            401:
+                description: Unauthorized access.
+            404:
+                description: Resource does not exist.
         """
         instance = self.get_object(identifier)
         return self.collection(instance.versions.serialize())
@@ -346,9 +423,10 @@ class VersionedModelEnpoint(ModelEndpoint):
         tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
             - name: ref
               in: path
-              type: string
+              type: integer
               required: true
               description: version reference, either a date or an increment.
         responses:
@@ -356,6 +434,12 @@ class VersionedModelEnpoint(ModelEndpoint):
                 description: get specific Version for resource {resource}.
                 schema:
                     $ref: '#/definitions/Version'
+            400:
+                description: Bad Request.
+            401:
+                description: Unauthorized access.
+            404:
+                description: Resource does not exist.
         """
         instance = self.get_object(identifier)
         version = instance.load_version(ref)
@@ -372,14 +456,25 @@ class VersionedModelEnpoint(ModelEndpoint):
         tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
             - name: ref
               in: path
-              type: string
+              type: integer
               required: true
               description: version reference, either a date or an increment.
+            - name: body
+              in: body
+              type: string
+              required: true
+              description:
+                A status boolean key (= true to flag, false to unflag).
         responses:
-            204:
+            200:
                 description: version flag was updated.
+            400:
+                description: Bad Request.
+            401:
+                description: Unauthorized access.
         """
         instance = self.get_object(identifier)
         version = instance.load_version(ref)
@@ -401,14 +496,19 @@ class VersionedModelEnpoint(ModelEndpoint):
         tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
             - name: old
               in: path
               type: string
               required: true
-              description: old identifier.
+              description: Old {resource} identifier:value
         responses:
             201:
-                description: redirect was created.
+                description: redirect was successfully created.
+            401:
+                description: Unauthorized access.
+            404:
+                description: Resource does not exist.
             422:
                 description: error while creating the redirect.
         """
@@ -428,16 +528,21 @@ class VersionedModelEnpoint(ModelEndpoint):
         tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
             - name: old
               in: path
               type: string
               required: true
-              description: old identifier.
+              description: old {resource} identifier:value
         responses:
             204:
-                description: redirect was successful.
+                description: redirect was successfully deleted.
+            401:
+                description: Unauthorized access.
+            404:
+                description: Resource does not exist.
             422:
-                description: error while creating the redirect.
+                description: error while deleting the redirect.
         """
         instance = self.get_object(identifier)
         old_identifier, old_value = old.split(':')
@@ -453,9 +558,14 @@ class VersionedModelEnpoint(ModelEndpoint):
         tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
         responses:
             200:
-                description: A list of redirects.
+                description: A list of redirects (identifier:value)
+            401:
+                description: Unauthorized access.
+            404:
+                description: Resource does not exist.
         """
         instance = self.get_object(identifier)
         cls = versioning.Redirect
@@ -571,18 +681,31 @@ class DiffEndpoint(CollectionEndpoint):
         """Get database diffs.
 
         tags: ['Diff']
-
         parameters:
-        - name: increment
-          in: query
-          description: The minimal increment value to retrieve
-          type: integer
-          required: false
+            - name: increment
+              in: query
+              description: The minimal increment value to retrieve
+              type: integer
+              required: false
         responses:
-          200:
-            description: A list of diff objects
-            schema:
-              $ref: '#/definitions/Diff'
+            200:
+                description: A list of diff objects
+                schema:
+                    type: object
+                    properties:
+                        total:
+                            name: total
+                            type: integer
+                            description: total resources available
+                        collection:
+                            name: collection
+                            type: array
+                            items:
+                                $ref: '#/definitions/Diff'
+            400:
+                description: Invalid value for increment
+            401:
+                description: Unauthorized access.
          """
         qs = versioning.Diff.select()
         try:

--- a/ban/http/api.py
+++ b/ban/http/api.py
@@ -506,6 +506,17 @@ class VersionedModelEnpoint(ModelEndpoint):
         responses:
             201:
                 description: redirect was successfully created.
+                schema:
+                    type: object
+                    properties:
+                        collection:
+                            type: array
+                            items:
+                                $ref: '#/definitions/Redirect'
+                        total:
+                            name: total
+                            type: integer
+                            description: total resources available
             401:
                 $ref: '#/responses/401'
             404:
@@ -538,6 +549,17 @@ class VersionedModelEnpoint(ModelEndpoint):
         responses:
             204:
                 description: redirect was successfully deleted.
+                schema:
+                    type: object
+                    properties:
+                        collection:
+                            type: array
+                            items:
+                                $ref: '#/definitions/Redirect'
+                        total:
+                            name: total
+                            type: integer
+                            description: total resources available
             401:
                 $ref: '#/responses/401'
             404:
@@ -563,6 +585,17 @@ class VersionedModelEnpoint(ModelEndpoint):
         responses:
             200:
                 description: A list of redirects (identifier:value)
+                schema:
+                    type: object
+                    properties:
+                        collection:
+                            type: array
+                            items:
+                                $ref: '#/definitions/Redirect'
+                        total:
+                            name: total
+                            type: integer
+                            description: total resources available
             401:
                 $ref: '#/responses/401'
             404:
@@ -731,3 +764,4 @@ app._schema.register_model(amodels.Session)
 app._schema.register_model(versioning.Diff)
 app._schema.register_model(versioning.Version)
 app._schema.register_model(versioning.Flag)
+app._schema.register_model(versioning.Redirect)

--- a/ban/http/api.py
+++ b/ban/http/api.py
@@ -130,7 +130,6 @@ class ModelEndpoint(CollectionEndpoint):
     def get_collection(self):
         """Get {resource} collection.
 
-        tags: [{resource}]
         responses:
             200:
                 description: Get {resource} collection.
@@ -168,7 +167,6 @@ class ModelEndpoint(CollectionEndpoint):
     def get_resource(self, identifier):
         """Get {resource} with 'identifier'.
 
-        tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
               description: {resource} identifier
@@ -194,7 +192,6 @@ class ModelEndpoint(CollectionEndpoint):
     def post_resource(self, identifier):
         """Post {resource} with 'identifier'.
 
-        tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
               description: {resource} identifier
@@ -235,7 +232,6 @@ class ModelEndpoint(CollectionEndpoint):
     def post(self):
         """Create a {resource}.
 
-        tags: [{resource}]
         parameters:
             - name: body
               in: body
@@ -273,7 +269,6 @@ class ModelEndpoint(CollectionEndpoint):
     def patch(self, identifier):
         """Patch {resource} with 'identifier'.
 
-        tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
               description: {resource} identifier
@@ -314,7 +309,6 @@ class ModelEndpoint(CollectionEndpoint):
     def put(self, identifier):
         """Replace {resource} with 'identifier'.
 
-        tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
               description: {resource} identifier
@@ -355,7 +349,6 @@ class ModelEndpoint(CollectionEndpoint):
     def delete(self, identifier):
         """Delete {resource}.
 
-        tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
         responses:
@@ -388,7 +381,6 @@ class VersionedModelEnpoint(ModelEndpoint):
     def get_versions(self, identifier):
         """Get {resource} versions.
 
-        tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
               description: {resource} identifier
@@ -421,7 +413,6 @@ class VersionedModelEnpoint(ModelEndpoint):
     def get_version(self, identifier, ref):
         """Get {resource} version corresponding to 'ref' number or datetime.
 
-        tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
               description: {resource} identifier
@@ -454,7 +445,6 @@ class VersionedModelEnpoint(ModelEndpoint):
     def post_version(self, identifier, ref):
         """Flag a {resource} version.
 
-        tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
               description: {resource} identifier
@@ -494,7 +484,6 @@ class VersionedModelEnpoint(ModelEndpoint):
     def put_redirects(self, identifier, old):
         """Create a new redirect to this {resource}.
 
-        tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
               description: {resource} identifier
@@ -537,7 +526,6 @@ class VersionedModelEnpoint(ModelEndpoint):
     def delete_redirects(self, identifier, old):
         """Delete a redirect to this {resource}.
 
-        tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
               description: {resource} identifier
@@ -578,7 +566,6 @@ class VersionedModelEnpoint(ModelEndpoint):
     def get_redirects(self, identifier):
         """Get a collection of Redirect pointing to this {resource}.
 
-        tags: [{resource}]
         parameters:
             - $ref: '#/parameters/identifier'
               description: {resource} identifier
@@ -714,7 +701,6 @@ class Diff(CollectionEndpoint):
     def get_collection(self):
         """Get database diffs.
 
-        tags: ['Diff']
         parameters:
             - name: increment
               in: query

--- a/ban/http/api.py
+++ b/ban/http/api.py
@@ -1,7 +1,7 @@
 from io import StringIO
 from urllib.parse import urlencode
 
-import json
+# import json
 import peewee
 from flask import request, url_for
 
@@ -721,9 +721,10 @@ class Diff(CollectionEndpoint):
         return self.collection(qs.serialize())
 
 
+@app.jsonify
 @app.route('/openapi', methods=['GET'])
 def openapi():
-    return json.dumps(app._schema, sort_keys=True)
+    return dumps(app._schema, sort_keys=True)
 
 
 app._schema.register_model(amodels.Session)

--- a/ban/http/schema.py
+++ b/ban/http/schema.py
@@ -17,7 +17,7 @@ BASE = {
         'version': __version__,
     },
     'swagger': '2.0',
-    'schemes': ['https'],
+    'schemes': ['http'],
     'consumes': ['application/json'],
     'produces': ['application/json'],
     'externalDocs': {
@@ -95,7 +95,7 @@ class Schema(dict):
     def model_definition(self, model):
         """Map Peewee models to jsonschema."""
         schema = {'required': [], 'properties': {},
-                  'type': ['object', 'string', 'null']}
+                  'type': 'object'}
         for name, field in model._meta.fields.items():
             if name not in model.resource_fields:
                 continue
@@ -105,7 +105,7 @@ class Schema(dict):
             if not type_:
                 continue
             row = {
-                'type': [type_]
+                'type': type_
             }
             if hasattr(field.__class__, '__schema_format__'):
                 row['format'] = field.__class__.__schema_format__
@@ -120,27 +120,28 @@ class Schema(dict):
                 }
             elif type_ == 'array':
                 row['items'] = {'type': field.db_field}
-            if field.null and 'type' in row:
-                row['type'].append('null')
+            # if field.null and 'type' in row:
+            #    row['type'].append('null')
             if field.unique:
                 row['unique'] = True
-            max_length = getattr(field, 'max_length', None)
-            if max_length:
-                row['maxLength'] = max_length
-            min_length = getattr(field, 'min_length', None)
-            if not min_length and type_ == 'string' and not field.null:
-                min_length = 1
-            if min_length:
-                row['minLength'] = min_length
+            # max_length = getattr(field, 'max_length', None)
+            # if max_length:
+            #    row['maxLength'] = max_length
+            # min_length = getattr(field, 'min_length', None)
+            # if not min_length and type_ == 'string' and not field.null:
+            #    min_length = 1
+            # if min_length:
+            #    row['minLength'] = min_length
             if getattr(field, 'choices', None):
                 row['enum'] = [v for v, l in field.choices]
                 if field.null:
-                    row['enum'].append(None)
+                    row['enum'].append('null')
             schema['properties'][name] = row
             readonly = name in model.readonly_fields
             if (not field.null and not readonly
                and name not in schema['required']):
                 schema['required'].append(name)
+
         return schema
 
     def register_endpoint(self, path, func, methods, endpoint):

--- a/ban/http/schema.py
+++ b/ban/http/schema.py
@@ -54,6 +54,17 @@ BASE = {
             'type': 'string',
             'required': True,
         }
+    },
+    'responses': {
+        '400': {
+            'description': 'Bad Request.'
+        },
+        '401': {
+            'description': 'Unauthorized access.'
+        },
+        '404': {
+            'description': 'Resource does not exist.'
+        },
     }
 }
 

--- a/ban/http/schema.py
+++ b/ban/http/schema.py
@@ -24,6 +24,15 @@ BASE = {
         'url': 'https://adresse.data.gouv.fr/api-gestion/',
     },
     'paths': {},
+    'tags': [
+        {'name': 'Municipality'},
+        {'name': 'Postcode'},
+        {'name': 'Group'},
+        {'name': 'Housenumber'},
+        {'name': 'Position'},
+        {'name': 'Diff'},
+        {'name': 'User'},
+    ],
     'definitions': {
         'Error': {
             'properties': {

--- a/ban/http/schema.py
+++ b/ban/http/schema.py
@@ -66,7 +66,7 @@ class Schema(dict):
 
     def get_responder_summary(self, responder, resource):
         return (responder.__doc__ or '').split('\n\n')[0].format(
-            resource=resource.__class__.__name__)
+            resource=resource.__name__)
 
     def get_responder_doc(self, func, resource):
         default = {

--- a/ban/http/schema.py
+++ b/ban/http/schema.py
@@ -24,15 +24,6 @@ BASE = {
         'url': 'https://adresse.data.gouv.fr/api-gestion/',
     },
     'paths': {},
-    'tags': [
-        {'name': 'Municipality'},
-        {'name': 'Postcode'},
-        {'name': 'Group'},
-        {'name': 'Housenumber'},
-        {'name': 'Position'},
-        {'name': 'Diff'},
-        {'name': 'User'},
-    ],
     'definitions': {
         'Error': {
             'properties': {

--- a/ban/http/schema.py
+++ b/ban/http/schema.py
@@ -124,14 +124,14 @@ class Schema(dict):
             #    row['type'].append('null')
             if field.unique:
                 row['unique'] = True
-            # max_length = getattr(field, 'max_length', None)
-            # if max_length:
-            #    row['maxLength'] = max_length
-            # min_length = getattr(field, 'min_length', None)
-            # if not min_length and type_ == 'string' and not field.null:
-            #    min_length = 1
-            # if min_length:
-            #    row['minLength'] = min_length
+            max_length = getattr(field, 'max_length', None)
+            if max_length:
+                row['maxLength'] = max_length
+            min_length = getattr(field, 'min_length', None)
+            if not min_length and type_ == 'string' and not field.null:
+                min_length = 1
+            if min_length:
+                row['minLength'] = min_length
             if getattr(field, 'choices', None):
                 row['enum'] = [v for v, l in field.choices]
                 if field.null:

--- a/ban/http/schema.py
+++ b/ban/http/schema.py
@@ -66,7 +66,7 @@ class Schema(dict):
 
     def get_responder_summary(self, responder, resource):
         return (responder.__doc__ or '').split('\n\n')[0].format(
-            resource=resource.__name__)
+            resource=resource.__name__.lower())
 
     def get_responder_doc(self, func, resource):
         default = {


### PR DESCRIPTION
This PR allow to use /openapi json in SwaggerUI.

- [x] Group operations by resource
- [x] Schema return the right resource name
- [x] Standardization of operations descriptions
- [x] Operations are now alphabetically ordered (Easier to read)
- [x] Entire api.operations._ _doc_ _ are now processed
- [x] Check all Resources/Actions/Routes
- [x] Reactivate minLength & maxLength schema properties
- [x] Generic error message definition
- [x] Rename DiffEndPoint api class in Diff class name
- [x] Openapi json alphabetically sorted with jsonify
- [x] Add Redirect model definition in openapi json export
- [ ] Allow redirections for date or sequential increment (currently only version is working)
- [ ] Define 'link model' for postcode, group, housenumber, position to simplify user read ?
