### PR TITLE
Openapi > SwaggerUI compatibilty...

### DIFF
--- a/ban/core/encoder.py
+++ b/ban/core/encoder.py
@@ -15,5 +15,6 @@ class ResourceEncoder(json.JSONEncoder):
             return o.__json__()
 
 
-def dumps(data):
-    return json.dumps(data, cls=ResourceEncoder)
+def dumps(data, **kwargs):
+    kwargs.setdefault('cls', ResourceEncoder)
+    return json.dumps(data, **kwargs)

--- a/ban/core/versioning.py
+++ b/ban/core/versioning.py
@@ -272,6 +272,13 @@ class Diff(db.Model):
 
 class Redirect(db.Model):
 
+    __openapi__ = """
+        properties:
+            identifier_value:
+                type: string
+                description: Identifier name ':' Value for identifier
+        """
+
     model_name = db.CharField(max_length=64)
     model_id = db.CharField(max_length=255)
     identifier = db.CharField(max_length=64)

--- a/ban/http/api.py
+++ b/ban/http/api.py
@@ -149,6 +149,9 @@ class ModelEndpoint(CollectionEndpoint):
                         name: total
                         type: integer
                         description: total resources available
+            401:
+                $ref: '#/responses/401'
+
         """
         qs = self.get_queryset()
         if qs is None:
@@ -170,15 +173,16 @@ class ModelEndpoint(CollectionEndpoint):
 
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
         responses:
             200:
                 description: Get {resource} instance.
                 schema:
                     $ref: '#/definitions/{resource}'
-            410:
-                description: Resource is deleted.
-                schema:
-                    $ref: '#/definitions/{resource}'
+            401:
+                $ref: '#/responses/401'
+            404:
+                $ref: '#/responses/404'
         """
         instance = self.get_object(identifier)
         status = 410 if instance.deleted_at else 200
@@ -191,23 +195,33 @@ class ModelEndpoint(CollectionEndpoint):
     @app.jsonify
     @app.endpoint('/<identifier>', methods=['POST'])
     def post_resource(self, identifier):
-        """Patch {resource} with 'identifier'.
+        """Post {resource} with 'identifier'.
 
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
+            - name: body
+              in: body
+              schema:
+                $ref: '#/definitions/{resource}'
+              required: true
+              description:
+                {resource} object that needs to be updated to the BAN
         responses:
             200:
-                description: Instance has been updated successfully.
+                description: Instance has been successfully updated.
                 schema:
                     $ref: '#/definitions/{resource}'
-            409:
+            400:
+                $ref: '#/responses/400'
+            401:
+                $ref: '#/responses/401'
+            404:
+                $ref: '#/responses/404'
+            419:
                 description: Conflict.
                 schema:
                     $ref: '#/definitions/{resource}'
-            410:
-                description: Resource is deleted.
-                schema:
-                    $ref: '#/definitions/Error'
             422:
                 description: Invalid data.
                 schema:
@@ -221,21 +235,29 @@ class ModelEndpoint(CollectionEndpoint):
     @app.jsonify
     @app.endpoint('', methods=['POST'])
     def post(self):
-        """Create {resource}
+        """Create a {resource}.
 
+        parameters:
+            - name: body
+              in: body
+              schema:
+                $ref: '#/definitions/{resource}'
+              required: true
+              description:
+                {resource} object that needs to be added to the BAN
         responses:
             201:
                 description: Instance has been created successfully.
                 schema:
                     $ref: '#/definitions/{resource}'
-            409:
+            400:
+                $ref: '#/responses/400'
+            401:
+                $ref: '#/responses/401'
+            419:
                 description: Conflict.
                 schema:
                     $ref: '#/definitions/{resource}'
-            410:
-                description: Resource is deleted.
-                schema:
-                    $ref: '#/definitions/Error'
             422:
                 description: Invalid data.
                 schema:
@@ -250,23 +272,33 @@ class ModelEndpoint(CollectionEndpoint):
     @app.jsonify
     @app.endpoint('/<identifier>', methods=['PATCH'])
     def patch(self, identifier):
-        """Patch {resource}
+        """Patch {resource} with 'identifier'.
 
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
+            - name: body
+              in: body
+              schema:
+                $ref: '#/definitions/{resource}'
+              required: true
+              description:
+                {resource} object that needs to be updated to the BAN
         responses:
             200:
                 description: Instance has been updated successfully.
                 schema:
                     $ref: '#/definitions/{resource}'
-            409:
+            400:
+                $ref: '#/responses/400'
+            401:
+                $ref: '#/responses/401'
+            404:
+                $ref: '#/responses/404'
+            419:
                 description: Conflict.
                 schema:
                     $ref: '#/definitions/{resource}'
-            410:
-                description: Resource is deleted.
-                schema:
-                    $ref: '#/definitions/Error'
             422:
                 description: Invalid data.
                 schema:
@@ -280,23 +312,33 @@ class ModelEndpoint(CollectionEndpoint):
     @app.jsonify
     @app.endpoint('/<identifier>', methods=['PUT'])
     def put(self, identifier):
-        """Replace or restore {resource}.
+        """Replace {resource} with 'identifier'.
 
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
+            - name: body
+              in: body
+              schema:
+                $ref: '#/definitions/{resource}'
+              required: true
+              description:
+                {resource} object that needs to be replaced to the BAN
         responses:
             200:
                 description: Instance has been replaced successfully.
                 schema:
                     $ref: '#/definitions/{resource}'
-            409:
+            400:
+                $ref: '#/responses/400'
+            401:
+                $ref: '#/responses/401'
+            404:
+                $ref: '#/responses/404'
+            419:
                 description: Conflict.
                 schema:
                     $ref: '#/definitions/{resource}'
-            410:
-                description: Resource is deleted.
-                schema:
-                    $ref: '#/definitions/Error'
             422:
                 description: Invalid data.
                 schema:
@@ -324,14 +366,14 @@ class ModelEndpoint(CollectionEndpoint):
                 description: Instance has been deleted successfully.
                 schema:
                     $ref: '#/definitions/{resource}'
-            409:
+            401:
+                $ref: '#/responses/401'
+            404:
+                $ref: '#/responses/404'
+            419:
                 description: Conflict.
                 schema:
                     $ref: '#/definitions/{resource}'
-            410:
-                description: Resource is already deleted.
-                schema:
-                    $ref: '#/definitions/Error'
         """
         instance = self.get_object(identifier)
         try:
@@ -346,17 +388,29 @@ class VersionedModelEnpoint(ModelEndpoint):
     @app.jsonify
     @app.endpoint('/<identifier>/versions', methods=['GET'])
     def get_versions(self, identifier):
-        """Get resource versions.
+        """Get {resource} versions.
 
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
         responses:
             200:
                 description: Version collection for resource {resource}.
                 schema:
-                    type: array
-                    items:
-                        $ref: '#/definitions/Version'
+                    type: object
+                    properties:
+                        collection:
+                            type: array
+                            items:
+                                $ref: '#/definitions/Version'
+                        total:
+                            name: total
+                            type: integer
+                            description: total resources available
+            401:
+                $ref: '#/responses/401'
+            404:
+                $ref: '#/responses/404'
         """
         instance = self.get_object(identifier)
         return self.collection(instance.versions.serialize())
@@ -370,9 +424,10 @@ class VersionedModelEnpoint(ModelEndpoint):
 
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
             - name: ref
               in: path
-              type: string
+              type: integer
               required: true
               description: version reference, either a date or an increment.
         responses:
@@ -380,6 +435,12 @@ class VersionedModelEnpoint(ModelEndpoint):
                 description: get specific Version for resource {resource}.
                 schema:
                     $ref: '#/definitions/Version'
+            400:
+                $ref: '#/responses/400'
+            401:
+                $ref: '#/responses/401'
+            404:
+                $ref: '#/responses/404'
         """
         instance = self.get_object(identifier)
         version = instance.load_version(ref)
@@ -391,18 +452,29 @@ class VersionedModelEnpoint(ModelEndpoint):
     @app.jsonify
     @app.endpoint('/<identifier>/versions/<int:ref>/flag', methods=['POST'])
     def post_version(self, identifier, ref):
-        """Flag a version.
+        """Flag a {resource} version.
 
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
             - name: ref
               in: path
-              type: string
+              type: integer
               required: true
               description: version reference, either a date or an increment.
+            - name: body
+              in: body
+              type: string
+              required: true
+              description:
+                A status boolean key (= true to flag, false to unflag).
         responses:
-            204:
+            200:
                 description: version flag was updated.
+            400:
+                $ref: '#/responses/400'
+            401:
+                $ref: '#/responses/401'
         """
         instance = self.get_object(identifier)
         version = instance.load_version(ref)
@@ -417,48 +489,113 @@ class VersionedModelEnpoint(ModelEndpoint):
             abort(400, error='Body should contain a `status` boolean key')
 
     @auth.require_oauth()
-    @app.endpoint('/<identifier>/redirects/<old>', methods=['PUT', 'DELETE'])
-    def put_delete_redirects(self, identifier, old):
-        """Create a new redirect to this resource.
+    @app.endpoint('/<identifier>/redirects/<old>', methods=['PUT'])
+    def put_redirects(self, identifier, old):
+        """Create a new redirect to this {resource}.
 
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
             - name: old
               in: path
               type: string
               required: true
-              description: old identifier.
+              description: Old {resource} identifier:value
         responses:
-            204:
-                description: redirect was successful.
             201:
-                description: redirect was created.
+                description: redirect was successfully created.
+                schema:
+                    type: object
+                    properties:
+                        collection:
+                            type: array
+                            items:
+                                $ref: '#/definitions/Redirect'
+                        total:
+                            name: total
+                            type: integer
+                            description: total resources available
+            401:
+                $ref: '#/responses/401'
+            404:
+                $ref: '#/responses/404'
             422:
                 description: error while creating the redirect.
         """
         instance = self.get_object(identifier)
         old_identifier, old_value = old.split(':')
-        if request.method == 'PUT':
-            try:
-                versioning.Redirect.add(instance, old_identifier, old_value)
-            except ValueError as e:
-                abort(422, error=str(e))
-            return '', 201
-        elif request.method == 'DELETE':
-            versioning.Redirect.remove(instance, old_identifier, old_value)
-            return '', 204
+        try:
+            versioning.Redirect.add(instance, old_identifier, old_value)
+        except ValueError as e:
+            abort(422, error=str(e))
+        return '', 201
+
+    @auth.require_oauth()
+    @app.endpoint('/<identifier>/redirects/<old>', methods=['DELETE'])
+    def delete_redirects(self, identifier, old):
+        """Delete a redirect to this {resource}.
+
+        parameters:
+            - $ref: '#/parameters/identifier'
+              description: {resource} identifier
+            - name: old
+              in: path
+              type: string
+              required: true
+              description: old {resource} identifier:value
+        responses:
+            204:
+                description: redirect was successfully deleted.
+                schema:
+                    type: object
+                    properties:
+                        collection:
+                            type: array
+                            items:
+                                $ref: '#/definitions/Redirect'
+                        total:
+                            name: total
+                            type: integer
+                            description: total resources available
+            401:
+                $ref: '#/responses/401'
+            404:
+                $ref: '#/responses/404'
+            422:
+                description: error while deleting the redirect.
+        """
+        instance = self.get_object(identifier)
+        old_identifier, old_value = old.split(':')
+        versioning.Redirect.remove(instance, old_identifier, old_value)
+        return '', 204
 
     @auth.require_oauth()
     @app.jsonify
     @app.endpoint('/<identifier>/redirects', methods=['GET'])
     def get_redirects(self, identifier):
-        """Get a collection of Redirect pointing to this resource.
+        """Get a collection of Redirect pointing to this {resource}.
 
         parameters:
             - $ref: '#/parameters/identifier'
+              description: {resource} identifier
         responses:
             200:
-                description: A list of redirects.
+                description: A list of redirects (identifier:value)
+                schema:
+                    type: object
+                    properties:
+                        collection:
+                            type: array
+                            items:
+                                $ref: '#/definitions/Redirect'
+                        total:
+                            name: total
+                            type: integer
+                            description: total resources available
+            401:
+                $ref: '#/responses/401'
+            404:
+                $ref: '#/responses/404'
         """
         instance = self.get_object(identifier)
         cls = versioning.Redirect
@@ -563,7 +700,7 @@ def bal_post():
 
 
 @app.resource
-class DiffEndpoint(CollectionEndpoint):
+class Diff(CollectionEndpoint):
     endpoint = '/diff'
     model = versioning.Diff
 
@@ -574,16 +711,31 @@ class DiffEndpoint(CollectionEndpoint):
         """Get database diffs.
 
         parameters:
-        - name: increment
-          in: query
-          description: The minimal increment value to retrieve
-          type: integer
-          required: false
+            - name: increment
+              in: query
+              description: The minimal increment value to retrieve
+              type: integer
+              required: false
         responses:
-          200:
-            description: A list of diff objects
-            schema:
-              $ref: '#/definitions/Diff'
+            200:
+                description: A list of diff objects
+                schema:
+                    type: object
+                    properties:
+                        total:
+                            name: total
+                            type: integer
+                            description: total resources available
+                        collection:
+                            name: collection
+                            type: array
+                            items:
+                                $ref: '#/definitions/Diff'
+            400:
+                description: Invalid value for increment
+            401:
+                $ref: '#/responses/401'
+
          """
         qs = versioning.Diff.select()
         try:
@@ -599,10 +751,11 @@ class DiffEndpoint(CollectionEndpoint):
 
 @app.route('/openapi', methods=['GET'])
 def openapi():
-    return dumps(app._schema)
+    return dumps(app._schema, sort_keys=True)
 
 
 app._schema.register_model(amodels.Session)
 app._schema.register_model(versioning.Diff)
 app._schema.register_model(versioning.Version)
 app._schema.register_model(versioning.Flag)
+app._schema.register_model(versioning.Redirect)

--- a/ban/http/schema.py
+++ b/ban/http/schema.py
@@ -17,7 +17,7 @@ BASE = {
         'version': __version__,
     },
     'swagger': '2.0',
-    'schemes': ['https'],
+    'schemes': ['http'],
     'consumes': ['application/json'],
     'produces': ['application/json'],
     'externalDocs': {
@@ -45,6 +45,17 @@ BASE = {
             'type': 'string',
             'required': True,
         }
+    },
+    'responses': {
+        '400': {
+            'description': 'Bad Request.'
+        },
+        '401': {
+            'description': 'Unauthorized access.'
+        },
+        '404': {
+            'description': 'Resource does not exist.'
+        },
     }
 }
 
@@ -86,7 +97,7 @@ class Schema(dict):
     def model_definition(self, model):
         """Map Peewee models to jsonschema."""
         schema = {'required': [], 'properties': {},
-                  'type': ['object', 'string', 'null']}
+                  'type': 'object'}
         for name, field in model._meta.fields.items():
             if name not in model.resource_fields:
                 continue
@@ -96,7 +107,7 @@ class Schema(dict):
             if not type_:
                 continue
             row = {
-                'type': [type_]
+                'type': type_
             }
             if hasattr(field.__class__, '__schema_format__'):
                 row['format'] = field.__class__.__schema_format__
@@ -111,8 +122,8 @@ class Schema(dict):
                 }
             elif type_ == 'array':
                 row['items'] = {'type': field.db_field}
-            if field.null and 'type' in row:
-                row['type'].append('null')
+            # if field.null and 'type' in row:
+            #     row['type'].append('null')
             if field.unique:
                 row['unique'] = True
             max_length = getattr(field, 'max_length', None)
@@ -126,7 +137,7 @@ class Schema(dict):
             if getattr(field, 'choices', None):
                 row['enum'] = [v for v, l in field.choices]
                 if field.null:
-                    row['enum'].append(None)
+                    row['enum'].append('null')
             schema['properties'][name] = row
             readonly = name in model.readonly_fields
             if (not field.null and not readonly

--- a/ban/http/schema.py
+++ b/ban/http/schema.py
@@ -17,7 +17,7 @@ BASE = {
         'version': __version__,
     },
     'swagger': '2.0',
-    'schemes': ['http'],
+    'schemes': ['https'],
     'consumes': ['application/json'],
     'produces': ['application/json'],
     'externalDocs': {


### PR DESCRIPTION
This PR allow to use /openapi json in SwaggerUI.

- [x] Group operations by resource
- [x] Schema return the right resource name
- [x] Standardization of operations descriptions
- [x] Operations are now alphabetically ordered (Easier to read)
- [x] Entire api.operations._ _doc_ _ are now processed
- [x] Check all Resources/Actions/Routes
- [x] Reactivate minLength & maxLength schema properties
- [x] Generic error message definition
- [x] Rename DiffEndPoint api class in Diff class name
- [x] Openapi json alphabetically sorted with jsonify
- [x] Add Redirect model definition in openapi json export
