### PR TITLE
Postcode complement

### DIFF
--- a/ban/commands/init.py
+++ b/ban/commands/init.py
@@ -131,10 +131,13 @@ def process_postcode(row):
     attributes = {'source': row.pop('source')}
     name = row.get('name')
     code = row.get('postcode')
+    complement = row.get('complement')
     data = dict(name=name, code=code, municipality=municipality,
-                version=1, attributes=attributes)
+                version=1, attributes=attributes, complement=complement)
     instance = PostCode.select().join(Municipality).where(
-        PostCode.code == code, Municipality.insee == insee).first()
+        PostCode.complement == complement,
+        PostCode.code == code,
+        Municipality.insee == insee).first()
     if instance:
         return reporter.notice('PostCode already exists', code)
     validator = PostCode.validator(**data)

--- a/ban/core/models.py
+++ b/ban/core/models.py
@@ -53,14 +53,15 @@ class Municipality(NamedModel):
 
 
 class PostCode(NamedModel):
-    resource_fields = ['code', 'name', 'alias', 'municipality']
+    resource_fields = ['code', 'name', 'alias', 'complement', 'municipality']
 
+    complement = db.CharField(max_length=38, null=True)
     code = db.PostCodeField(index=True)
     municipality = db.ForeignKeyField(Municipality, related_name='postcodes')
 
     class Meta:
         indexes = (
-            (('code', 'municipality'), True),
+            (('code', 'complement', 'municipality'), True),
         )
 
     @property

--- a/ban/core/models.py
+++ b/ban/core/models.py
@@ -205,11 +205,6 @@ class Position(Model):
     laposte = db.CharField(max_length=10, null=True, unique=True)
     comment = db.TextField(null=True)
 
-    class Meta:
-        indexes = (
-            (('housenumber', 'source'), True),
-        )
-
     @classmethod
     def validate(cls, validator, document, instance):
         errors = {}

--- a/ban/tests/http/test_postcode.py
+++ b/ban/tests/http/test_postcode.py
@@ -6,11 +6,24 @@ from .utils import authorize
 
 @authorize
 def test_get_postcode(get):
-    postcode = PostCodeFactory(code="09350")
+    postcode = PostCodeFactory(code="09350", name="EPINAY SUR SEINE")
     resp = get('/postcode/{}'.format(postcode.id))
     assert resp.status_code == 200
-    assert resp.json['id']
-    assert resp.json['code'] == '09350'
+    assert resp.json == {
+        'id': postcode.id,
+        'name': 'EPINAY SUR SEINE',
+        'code': '09350',
+        'alias': None,
+        'modified_at': postcode.modified_at.isoformat(),
+        'created_at': postcode.created_at.isoformat(),
+        'modified_by': postcode.modified_by.serialize(),
+        'created_by': postcode.created_by.serialize(),
+        'attributes': None,
+        'status': 'active',
+        'version': 1,
+        'complement': None,
+        'municipality': postcode.municipality.id,
+    }
 
 
 @authorize
@@ -32,6 +45,18 @@ def test_create_postcode(client):
     assert models.PostCode.select().count() == 1
     uri = 'http://localhost/postcode/{}'.format(resp.json['id'])
     assert resp.headers['Location'] == uri
+
+
+@authorize
+def test_can_update_postcode_complement(client):
+    postcode = PostCodeFactory()
+    data = {
+        "complement": "SAINT SAINT",
+        "version": 2
+    }
+    resp = client.post('/postcode/{}'.format(postcode.id), data)
+    assert resp.status_code == 200
+    assert resp.json['complement'] == "SAINT SAINT"
 
 
 @authorize

--- a/ban/tests/test_models.py
+++ b/ban/tests/test_models.py
@@ -386,12 +386,3 @@ def test_position_center_coerce(given, expected):
         assert center.coords == expected
     else:
         assert not center
-
-
-def test_cannot_create_position_with_same_housenumber_and_source():
-    hn1 = HouseNumberFactory()
-    PositionFactory(housenumber=hn1, source="XXX")
-    assert models.Position.select().count() == 1
-    with pytest.raises(peewee.IntegrityError):
-        PositionFactory(housenumber=hn1, source="XXX")
-    assert models.Position.select().count() == 1


### PR DESCRIPTION
While working on this I also discovered that the multi columns unique indexes were not checked by the validor, which had some issues:

- when one value is "null", PostgreSQL does not consider the row for the unicity check, so one can add multiple times A=1,B=null,C=3 even if there is a unique constrainit on A,B,C
- when postgresql would complain because we are trying to add twice the same values, we were not catching it, so => 500
- as much as possible, we prefer to return all the errors in once to the user; so if we only tried to catch the SQL IntegrityError at save time, one may have a document returning some errors, then fix those errors, then send back the document, and get a new error, which is not friendly