### PR TITLE
Allow to validate fields format throught regex

### DIFF
--- a/ban/core/models.py
+++ b/ban/core/models.py
@@ -56,7 +56,7 @@ class PostCode(NamedModel):
     resource_fields = ['code', 'name', 'alias', 'complement', 'municipality']
 
     complement = db.CharField(max_length=38, null=True)
-    code = db.PostCodeField(index=True)
+    code = db.CharField(index=True, format='\d*', length=5)
     municipality = db.ForeignKeyField(Municipality, related_name='postcodes')
 
     class Meta:

--- a/ban/core/models.py
+++ b/ban/core/models.py
@@ -49,7 +49,7 @@ class Municipality(NamedModel):
     exclude_for_version = ['postcodes']
 
     insee = db.CharField(length=5, unique=True)
-    siren = db.CharField(max_length=9, unique=True, null=True)
+    siren = db.CharField(length=9, format='\d*', unique=True, null=True)
 
 
 class PostCode(NamedModel):

--- a/ban/core/models.py
+++ b/ban/core/models.py
@@ -48,7 +48,7 @@ class Municipality(NamedModel):
     resource_fields = ['name', 'alias', 'insee', 'siren', 'postcodes']
     exclude_for_version = ['postcodes']
 
-    insee = db.CharField(length=5, unique=True)
+    insee = db.CharField(length=5, unique=True, format='[\dAB]{2}\d{3}')
     siren = db.CharField(length=9, format='\d*', unique=True, null=True)
 
 

--- a/ban/core/validators.py
+++ b/ban/core/validators.py
@@ -59,7 +59,8 @@ class ResourceValidator:
             raise ValueError('`{value}` is not of type `{type}`.'.format(
                 value=value, type=field.__data_type__
             ))
-        checks = ['null', 'choices', 'min_length', 'max_length', 'unique']
+        checks = ['null', 'choices', 'min_length', 'max_length', 'regex',
+                  'unique']
         for check in checks:
             if getattr(field, check, None) is not None:
                 getattr(self, 'validate_{}'.format(check))(field, value)
@@ -89,6 +90,11 @@ class ResourceValidator:
             raise ValueError('`{}` should be maximum {} characters'.format(
                 value, field.max_length
             ))
+
+    def validate_regex(self, field, value):
+        if value and not bool(field.regex.fullmatch(value)):
+            raise ValueError('Wrong format. Value should '
+                             'match `{}`'.format(field.regex.pattern))
 
     def validate_unique(self, field, value):
         if not value or not field.unique:

--- a/ban/db/fields.py
+++ b/ban/db/fields.py
@@ -13,7 +13,7 @@ from ban.core.exceptions import ValidationError
 
 __all__ = ['PointField', 'ForeignKeyField', 'CharField', 'IntegerField',
            'HStoreField', 'UUIDField', 'ArrayField', 'DateTimeField',
-           'BooleanField', 'BinaryJSONField', 'PostCodeField', 'FantoirField',
+           'BooleanField', 'BinaryJSONField', 'FantoirField',
            'ManyToManyField', 'PasswordField', 'DateRangeField', 'TextField']
 
 
@@ -132,6 +132,8 @@ class CharField(peewee.CharField):
     __schema_type__ = 'string'
 
     def __init__(self, *args, **kwargs):
+        if 'format' in kwargs:
+            self.regex = re.compile(kwargs.pop('format'))
         if 'length' in kwargs:
             kwargs['min_length'] = kwargs['max_length'] = kwargs.pop('length')
         self.min_length = kwargs.pop('min_length', None)
@@ -208,17 +210,6 @@ class DateTimeField(postgres_ext.DateTimeTZField):
 class BooleanField(peewee.BooleanField):
     __data_type__ = bool
     __schema_type__ = 'boolean'
-
-
-class PostCodeField(CharField):
-
-    max_length = 5
-
-    def coerce(self, value):
-        value = str(value)
-        if not len(value) == 5 or not value.isdigit():
-            raise ValidationError('Invalid postcode: `{}`'.format(value))
-        return value
 
 
 class FantoirField(CharField):

--- a/ban/tests/test_validators.py
+++ b/ban/tests/test_validators.py
@@ -198,21 +198,22 @@ def test_cannot_create_postcode_with_code_shorter_than_5_chars(session):
     municipality = MunicipalityFactory(insee='12345')
     validator = models.PostCode.validator(code="3131", name="Montbrun-Bocage",
                                           municipality=municipality)
-    assert validator.errors['code'] == 'Invalid postcode: `3131`'
+    assert validator.errors['code'] == '`3131` should be minimum 5 characters'
 
 
 def test_cannot_create_postcode_with_code_bigger_than_5_chars(session):
     municipality = MunicipalityFactory(insee='12345')
     validator = models.PostCode.validator(code="313100", name="Montbrun",
                                           municipality=municipality)
-    assert validator.errors['code'] == 'Invalid postcode: `313100`'
+    assert validator.errors['code'] == ('`313100` should be maximum 5 '
+                                        'characters')
 
 
 def test_cannot_create_postcode_with_code_non_digit(session):
     municipality = MunicipalityFactory(insee='12345')
     validator = models.PostCode.validator(code="2A000", name="Montbrun-Bocage",
                                           municipality=municipality)
-    assert validator.errors['code'] == 'Invalid postcode: `2A000`'
+    assert validator.errors['code'] == 'Wrong format. Value should match `\d*`'
 
 
 def test_can_create_street(session):

--- a/ban/tests/test_validators.py
+++ b/ban/tests/test_validators.py
@@ -53,6 +53,11 @@ def test_cannot_create_municipality_with_insee_too_long(session):
     assert 'insee' in validator.errors
 
 
+def test_cannot_create_municipality_with_bad_insee(session):
+    validator = models.Municipality.validator(name="Eu", insee="test")
+    assert 'insee' in validator.errors
+
+
 def test_cannot_create_municipality_with_siren_too_short(session):
     validator = models.Municipality.validator(name="Eu", insee="12345",
                                               siren="12345678")

--- a/ban/tests/test_validators.py
+++ b/ban/tests/test_validators.py
@@ -9,17 +9,17 @@ from .factories import (GroupFactory, HouseNumberFactory, MunicipalityFactory,
 
 def test_can_create_municipality(session):
     validator = models.Municipality.validator(name="Eu", insee="12345",
-                                              siren="12345678")
+                                              siren="123456789")
     assert not validator.errors
     municipality = validator.save()
     assert municipality.name == "Eu"
     assert municipality.insee == "12345"
-    assert municipality.siren == "12345678"
+    assert municipality.siren == "123456789"
 
 
 def test_can_create_municipality_with_version(session):
     validator = models.Municipality.validator(name="Eu", insee="12345",
-                                              siren="12345678", version=1)
+                                              siren="123456789", version=1)
     assert not validator.errors
     municipality = validator.save()
     assert municipality.id
@@ -27,7 +27,7 @@ def test_can_create_municipality_with_version(session):
 
 def test_create_should_not_consider_bad_versions(session):
     validator = models.Municipality.validator(name="Eu", insee="12345",
-                                              siren="12345678", version=10)
+                                              siren="123456789", version=10)
     assert not validator.errors
     municipality = validator.save()
     assert municipality.id
@@ -43,14 +43,32 @@ def test_cannot_create_municipality_with_missing_fields(session):
 
 def test_cannot_create_municipality_with_insee_too_short(session):
     validator = models.Municipality.validator(name="Eu", insee="1234",
-                                              siren="12345678")
+                                              siren="123456789")
     assert 'insee' in validator.errors
 
 
 def test_cannot_create_municipality_with_insee_too_long(session):
     validator = models.Municipality.validator(name="Eu", insee="123456",
-                                              siren="12345678")
+                                              siren="123456789")
     assert 'insee' in validator.errors
+
+
+def test_cannot_create_municipality_with_siren_too_short(session):
+    validator = models.Municipality.validator(name="Eu", insee="12345",
+                                              siren="12345678")
+    assert 'siren' in validator.errors
+
+
+def test_cannot_create_municipality_with_siren_too_long(session):
+    validator = models.Municipality.validator(name="Eu", insee="12345",
+                                              siren="1234567890")
+    assert 'siren' in validator.errors
+
+
+def test_cannot_create_municipality_with_bad_siren(session):
+    validator = models.Municipality.validator(name="Eu", insee="12345",
+                                              siren="12345678A")
+    assert 'siren' in validator.errors
 
 
 def test_can_update_municipality(session):
@@ -111,7 +129,7 @@ def test_can_create_municipality_with_alias(session):
     validator = models.Municipality.validator(name="Orvane",
                                               alias=["Moret-sur-Loing"],
                                               insee="12345",
-                                              siren="12345678")
+                                              siren="123456789")
     assert not validator.errors
     municipality = validator.save()
     assert 'Moret-sur-Loing' in municipality.alias


### PR DESCRIPTION
Also replace PostCodeField by this new validation, and use it for Municipality.insee and Municipality.siren.

cf #257 

@davidbgk @vinyll r?