### PR TITLE
Add Diff.insee

### DIFF
--- a/ban/core/models.py
+++ b/ban/core/models.py
@@ -2,9 +2,10 @@ import re
 
 import peewee
 from unidecode import unidecode
+from werkzeug.utils import cached_property
 
 from ban import db
-from ban.utils import compute_cia, cached_property
+from ban.utils import compute_cia
 from .versioning import Versioned, BaseVersioned
 from .resource import ResourceModel, BaseResource
 from .validators import VersionedResourceValidator

--- a/ban/core/versioning.py
+++ b/ban/core/versioning.py
@@ -214,6 +214,9 @@ class Diff(db.Model):
 
     __openapi__ = """
         properties:
+            increment:
+                type: integer
+                description: incremental id of the diff
             resource:
                 type: string
                 description: name of the resource the diff is applied to

--- a/ban/core/versioning.py
+++ b/ban/core/versioning.py
@@ -76,7 +76,8 @@ class Versioned(db.Model, metaclass=BaseVersioned):
             old = self.load_version(self.version - 1)
             old.close_period(new.period.lower)
         if Diff.ACTIVE:
-            Diff.create(old=old, new=new, created_at=self.modified_at)
+            Diff.create(old=old, new=new, created_at=self.modified_at,
+                        insee=self.municipality.insee)
 
     @property
     def versions(self):
@@ -227,6 +228,10 @@ class Diff(db.Model):
                 type: string
                 format: date-time
                 description: the date and time the diff has been created at
+            insee:
+                type: string
+                description: INSEE code of the Municipality the resource
+                             is attached
             old:
                 type: object
                 description: the resource before the change
@@ -245,6 +250,7 @@ class Diff(db.Model):
     old = db.ForeignKeyField(Version, null=True)
     # new is empty after delete.
     new = db.ForeignKeyField(Version, null=True)
+    insee = db.CharField(length=5)
     diff = db.BinaryJSONField()
     created_at = db.DateTimeField()
 
@@ -264,6 +270,7 @@ class Diff(db.Model):
         version = self.new or self.old
         return {
             'increment': self.pk,
+            'insee': self.insee,
             'old': self.old.data if self.old else None,
             'new': self.new.data if self.new else None,
             'diff': self.diff,

--- a/ban/tests/http/test_diff.py
+++ b/ban/tests/http/test_diff.py
@@ -27,6 +27,7 @@ def test_diff_endpoint(client):
     street_create_diff = diffs[1]
     assert street_create_diff['increment'] == diffs[0]['increment'] + 1
     assert street_create_diff['old'] is None
+    assert street_create_diff['insee'] == street.municipality.insee
     assert street_create_diff['new']['id'] == street.id
     assert street_create_diff['resource_id'] == street.id
     street_update_diff = diffs[-1]

--- a/ban/tests/http/test_housenumber.py
+++ b/ban/tests/http/test_housenumber.py
@@ -125,7 +125,7 @@ def test_get_housenumber_with_districts(get):
     municipality = MunicipalityFactory()
     district = GroupFactory(municipality=municipality, kind=models.Group.AREA)
     housenumber = HouseNumberFactory(ancestors=[district],
-                                     municipality=municipality)
+                                     parent__municipality=municipality)
     resp = get('/housenumber/{}'.format(housenumber.id))
     assert resp.status_code == 200
     assert 'ancestors' in resp.json

--- a/ban/tests/test_models.py
+++ b/ban/tests/test_models.py
@@ -349,6 +349,18 @@ def test_housenumber_as_relation():
     }
 
 
+def test_housenumber_municipality_is_cached(mocker, sql_spy):
+    HouseNumberFactory()
+    # Reload the instance to clear property cache from Diff creation.
+    housenumber = models.HouseNumber.first()
+    expected = housenumber.parent.municipality
+    sql_spy.reset_mock()
+    assert housenumber.municipality == expected
+    assert sql_spy.call_count == 1
+    assert housenumber.municipality == expected
+    assert sql_spy.call_count == 1
+
+
 def test_position_children():
     housenumber = HouseNumberFactory()
     parent = PositionFactory(housenumber=housenumber)
@@ -386,3 +398,16 @@ def test_position_center_coerce(given, expected):
         assert center.coords == expected
     else:
         assert not center
+
+
+def test_position_municipality_is_cached(mocker, sql_spy):
+    PositionFactory()
+    # Load the model from scratch, otherwise Diff creation has already
+    # populated the "municipality" property
+    pos = models.Position.first()
+    expected = pos.housenumber.parent.municipality
+    sql_spy.reset_mock()
+    assert pos.municipality == expected
+    assert sql_spy.call_count == 1
+    assert pos.municipality == expected
+    assert sql_spy.call_count == 1

--- a/ban/utils.py
+++ b/ban/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from functools import wraps
 from uuid import UUID
 
 
@@ -57,3 +58,15 @@ def parse_mask(source):
                 parent[field] = {}
             parent = parent[field]
     return dest
+
+
+def cached_property(func):
+
+    @wraps(func)
+    def wrapped(inst):
+        key = '_cached_{}'.format(func.__name__)
+        if not hasattr(inst, key):
+            setattr(inst, key, func(inst))
+        return getattr(inst, key)
+
+    return property(wrapped)

--- a/ban/utils.py
+++ b/ban/utils.py
@@ -58,15 +58,3 @@ def parse_mask(source):
                 parent[field] = {}
             parent = parent[field]
     return dest
-
-
-def cached_property(func):
-
-    @wraps(func)
-    def wrapped(inst):
-        key = '_cached_{}'.format(func.__name__)
-        if not hasattr(inst, key):
-            setattr(inst, key, func(inst))
-        return getattr(inst, key)
-
-    return property(wrapped)

--- a/conftest.py
+++ b/conftest.py
@@ -101,6 +101,7 @@ class Client(FlaskClient):
                 kwargs['data'] = json.dumps(kwargs['data'])
         return super().open(*args, **kwargs)
 
+
 application.test_client_class = Client
 
 
@@ -148,3 +149,9 @@ def reporter():
     reporter_ = Reporter(2)
     context.set('reporter', reporter_)
     return reporter_
+
+
+@pytest.fixture
+def sql_spy(mocker):
+    from playhouse.postgres_ext import PostgresqlExtDatabase
+    return mocker.spy(PostgresqlExtDatabase, 'execute_sql')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
-pytest==3.0.5
-pytest-flask==0.10.0
 factory-boy==2.7.0
 factory-boy-peewee==0.0.4
 flex==6.0.1
+pytest==3.0.5
+pytest-flask==0.10.0
+pytest-mock==1.4.0


### PR DESCRIPTION
We attach the municipality as a "context" to each Diff.
We know a lot of diff consumers will need this info (starting by the monitoring tool), so we prefer to make the effort once instead of having a lot of requests in the API just to get this info.

Not sure about the final key naming: "insee", "context_insee", "municipality"?
Also, we may expose the municipality id instead of it's insee code.

Fix #239